### PR TITLE
fix(users): set server url correctly

### DIFF
--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -70,7 +70,7 @@ class LoadUsers(bpy.types.Operator):
         for profile in profiles:
             user = users.add()
             user.server_name = profile.serverInfo.name or "Speckle Server"
-            user.server= profile.serverInfo.url
+            user.server_url = profile.serverInfo.url
             user.name = profile.userInfo.name
             user.email= profile.userInfo.email
             user.company = profile.userInfo.company or ""


### PR DESCRIPTION
this was not getting set previously meaning operations did not work for
accounts on servers other than speckle.xyz


(( should have added this in the prev PR soz, but i just noticed it after merging 🙈 ))