### PR TITLE
feat(conversions): improvements for `from_speckle` conversions

### DIFF
--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -185,6 +185,8 @@ def from_speckle_object(speckle_object, scale, name=None):
         or getattr(speckle_object, "name", None)
         or speckle_object.speckle_type + f" -- {speckle_object.id}"
     )
+
+    # try native conversion
     if type(speckle_object) in FROM_SPECKLE_SCHEMAS.keys():
         print("Got object type: {}".format(type(speckle_object)))
 
@@ -213,14 +215,17 @@ def from_speckle_object(speckle_object, scale, name=None):
         # set_transform(speckle_object, blender_object)
 
         return blender_object
-    elif hasattr(speckle_object, "displayMesh"):
-        return from_speckle_object(speckle_object.displayMesh, scale, speckle_name)
-    elif hasattr(speckle_object, "displayValue"):
-        return from_speckle_object(speckle_object.displayValue, scale, speckle_name)
 
-    else:
-        _report("Invalid input: {}".format(speckle_object))
-        return None
+    # try display mesh
+    mesh = getattr(
+        speckle_object, "displayMesh", getattr(speckle_object, "displayValue", None)
+    )
+    if mesh:
+        return from_speckle_object(mesh, scale, speckle_name)
+
+    # return none if fail
+    _report("Invalid input: {}".format(speckle_object))
+    return None
 
 
 def get_speckle_subobjects(attr, scale, name):

--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -188,9 +188,13 @@ def from_speckle_object(speckle_object, scale, name=None):
             or speckle_object.speckle_type + f" -- {speckle_object.id}"
         )
 
-        obdata = FROM_SPECKLE_SCHEMAS[type(speckle_object)](
-            speckle_object, scale, speckle_name
-        )
+        try:
+            obdata = FROM_SPECKLE_SCHEMAS[type(speckle_object)](
+                speckle_object, scale, speckle_name
+            )
+        except Exception as e:  # conversion error
+            _report(f"Error converting {speckle_object} \n{e}")
+            return None
 
         if speckle_name in bpy.data.objects.keys():
             blender_object = bpy.data.objects[speckle_name]

--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -180,13 +180,13 @@ def dict_to_speckle_object(data):
 
 
 def from_speckle_object(speckle_object, scale, name=None):
+    speckle_name = (
+        name
+        or getattr(speckle_object, "name", None)
+        or speckle_object.speckle_type + f" -- {speckle_object.id}"
+    )
     if type(speckle_object) in FROM_SPECKLE_SCHEMAS.keys():
         print("Got object type: {}".format(type(speckle_object)))
-        speckle_name = (
-            name
-            or getattr(speckle_object, "name", None)
-            or speckle_object.speckle_type + f" -- {speckle_object.id}"
-        )
 
         try:
             obdata = FROM_SPECKLE_SCHEMAS[type(speckle_object)](
@@ -213,6 +213,10 @@ def from_speckle_object(speckle_object, scale, name=None):
         # set_transform(speckle_object, blender_object)
 
         return blender_object
+    elif hasattr(speckle_object, "displayMesh"):
+        return from_speckle_object(speckle_object.displayMesh, scale, speckle_name)
+    elif hasattr(speckle_object, "displayValue"):
+        return from_speckle_object(speckle_object.displayValue, scale, speckle_name)
 
     else:
         _report("Invalid input: {}".format(speckle_object))

--- a/bpy_speckle/convert/from_speckle/curve.py
+++ b/bpy_speckle/convert/from_speckle/curve.py
@@ -1,6 +1,6 @@
 import bpy, math
 from bpy_speckle.util import find_key_case_insensitive
-from mathutils import Vector, Quaternion
+import mathutils
 from specklepy.objects.geometry import *
 
 CONVERT = {}
@@ -85,7 +85,7 @@ def import_nurbs_curve(scurve, bcurve, scale):
                 1,
             )
 
-        if len(scurve.weights == len(nurbs.points)):
+        if len(scurve.weights) == len(nurbs.points):
             for i, w in enumerate(scurve.weights):
                 nurbs.points[i].weight = w
 
@@ -109,7 +109,7 @@ def import_arc(rcurve, bcurve, scale):
         return
 
     origin = plane.origin
-    normal = Vector(plane.normal.value)
+    normal = mathutils.Vector([plane.normal.x, plane.normal.y, plane.normal.z])
 
     xaxis = plane.xdir
     yaxis = plane.ydir
@@ -118,20 +118,20 @@ def import_arc(rcurve, bcurve, scale):
     startAngle = rcurve.startAngle
     endAngle = rcurve.endAngle
 
-    startQuat = Quaternion(normal, startAngle)
-    endQuat = Quaternion(normal, endAngle)
+    startQuat = mathutils.Quaternion(normal, startAngle)
+    endQuat = mathutils.Quaternion(normal, endAngle)
 
     """
     Get start and end vectors, centre point, angles, etc.
     """
 
-    r1 = Vector(plane.xdir.value)
+    r1 = mathutils.Vector([plane.xdir.x, plane.xdir.y, plane.xdir.z])
     r1.rotate(startQuat)
 
-    r2 = Vector(plane.xdir.value)
+    r2 = mathutils.Vector([plane.xdir.x, plane.xdir.y, plane.xdir.z])
     r2.rotate(endQuat)
 
-    c = Vector(plane.origin.value) * scale
+    c = mathutils.Vector([plane.origin.x, plane.origin.y, plane.origin.z]) * scale
 
     spt = c + r1 * radius
     ept = c + r2 * radius
@@ -149,7 +149,7 @@ def import_arc(rcurve, bcurve, scale):
 
     Ndiv = max(int(math.floor(angle / 0.3)), 2)
     step = angle / float(Ndiv)
-    stepQuat = Quaternion(normal, step)
+    stepQuat = mathutils.Quaternion(normal, step)
     tan = math.tan(step / 2) * radius
 
     arc.points.add(Ndiv + 1)

--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -1,7 +1,6 @@
 """
 Stream operators
 """
-
 import bpy, bmesh, os
 import webbrowser
 from bpy.props import (
@@ -234,7 +233,6 @@ class ReceiveStreamObjects(bpy.types.Operator):
             return {"CANCELLED"}
 
         name = "{} [ {} @ {} ]".format(stream.name, branch.name, commit.id)
-
         col = create_collection(name)
         col.speckle.stream_id = stream.id
         col.speckle.name = stream.name
@@ -380,12 +378,16 @@ class SendStreamObjects(bpy.types.Operator):
 
         transport = ServerTransport(client, stream.id)
 
-        obj_id = operations.send(base, [transport])
+        obj_id = operations.send(
+            base,
+            [transport],
+        )
         client.commit.create(
             stream.id,
             obj_id,
             branch.name,
             message=self.commit_message,
+            source_application="blender",
         )
 
         bpy.ops.speckle.load_user_streams()

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -83,7 +83,7 @@ class LoadUserStreams(bpy.types.Operator):
             client = speckle_clients[int(context.scene.speckle.active_user)]
 
             try:
-                streams = client.stream.list()
+                streams = client.stream.list(stream_limit=20)
             except Exception as e:
                 _report("Failed to retrieve streams: {}".format(e))
                 return


### PR DESCRIPTION
- fixes for arc and nurb conversions (rhino std geometry test file now comes through successfully!)
- log (just in console for now) and skip unsupported elements
- always try and fall back on display mesh / value but preserve actual speckle type as name (everything in revit test file except for room boundaries, model curves, openings, and direct shapes now at least show up as meshes with the correct name even if not truly converted)
- add "blender" as the source for commits
- increase stream fetch limit to 20
