### PR TITLE
Ngon Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # editor
 .vscode
+.idea
 
 # dev
 .venv

--- a/bpy_speckle/convert/from_speckle/mesh.py
+++ b/bpy_speckle/convert/from_speckle/mesh.py
@@ -28,11 +28,11 @@ def add_faces(smesh, bmesh, smooth=False):
         while i < len(sfaces):
             n = sfaces[i]
             if n < 3:
-                n += 3
+                n += 3  # 0 -> 3, 1 -> 4
 
             i += 1
             try:
-                f = bmesh.faces.new(sfaces[i, i + n])
+                f = bmesh.faces.new([bmesh.verts[int(x)] for x in sfaces[i: i + n]])
                 f.smooth = smooth
             except Exception as e:
                 _report(f"Failed to create face for mesh {smesh.id} \n{e}")

--- a/bpy_speckle/convert/from_speckle/mesh.py
+++ b/bpy_speckle/convert/from_speckle/mesh.py
@@ -26,38 +26,17 @@ def add_faces(smesh, bmesh, smooth=False):
         i = 0
         # TODO: why does `faces.new()` seem to fail so often?
         while i < len(sfaces):
-            if sfaces[i] == 0:
-                i += 1
-                try:
-                    f = bmesh.faces.new(
-                        (
-                            bmesh.verts[int(sfaces[i])],
-                            bmesh.verts[int(sfaces[i + 1])],
-                            bmesh.verts[int(sfaces[i + 2])],
-                        )
-                    )
-                    f.smooth = smooth
-                except Exception as e:
-                    _report(f"Failed to create face for mesh {smesh.id} \n{e}")
-                i += 3
-            elif sfaces[i] == 1:
-                i += 1
-                try:
-                    f = bmesh.faces.new(
-                        (
-                            bmesh.verts[int(sfaces[i])],
-                            bmesh.verts[int(sfaces[i + 1])],
-                            bmesh.verts[int(sfaces[i + 2])],
-                            bmesh.verts[int(sfaces[i + 3])],
-                        )
-                    )
-                    f.smooth = smooth
-                except Exception as e:
-                    _report(f"Failed to create face for mesh {smesh.id} \n{e}")
-                i += 4
-            else:
-                print("Invalid face length.\n" + str(sfaces[i]))
-                break
+            n = sfaces[i]
+            if n < 3:
+                n += 3
+
+            i += 1
+            try:
+                f = bmesh.faces.new(sfaces[i, i + n])
+                f.smooth = smooth
+            except Exception as e:
+                _report(f"Failed to create face for mesh {smesh.id} \n{e}")
+            i += n
 
         bmesh.faces.ensure_lookup_table()
         bmesh.verts.index_update()

--- a/bpy_speckle/convert/from_speckle/mesh.py
+++ b/bpy_speckle/convert/from_speckle/mesh.py
@@ -24,7 +24,6 @@ def add_faces(smesh, bmesh, smooth=False):
 
     if sfaces and len(sfaces) > 0:
         i = 0
-        # TODO: why does `faces.new()` seem to fail so often?
         while i < len(sfaces):
             n = sfaces[i]
             if n < 3:
@@ -32,7 +31,7 @@ def add_faces(smesh, bmesh, smooth=False):
 
             i += 1
             try:
-                f = bmesh.faces.new([bmesh.verts[int(x)] for x in sfaces[i: i + n]])
+                f = bmesh.faces.new([bmesh.verts[int(x)] for x in sfaces[i : i + n]])
                 f.smooth = smooth
             except Exception as e:
                 _report(f"Failed to create face for mesh {smesh.id} \n{e}")

--- a/bpy_speckle/convert/to_speckle/mesh.py
+++ b/bpy_speckle/convert/to_speckle/mesh.py
@@ -14,8 +14,6 @@ def export_mesh(blender_object, data, scale=1.0):
 
     verts = [tuple(mat @ x.co * scale) for x in data.vertices]
 
-    # TODO: add n-gon support, using tessfaces for now
-    # faces = [x.vertices for x in data.loop_triangles]
     faces = [p.vertices for p in data.polygons]
     unit_system = bpy.context.scene.unit_settings.system
 
@@ -34,12 +32,13 @@ def export_mesh(blender_object, data, scale=1.0):
             sm.textureCoordinates.extend([vt.uv.x, vt.uv.y])
 
     for f in faces:
-        if len(f) == 3:
+        n = len(f)
+        if n == 3:
             sm.faces.append(0)
-        elif len(f) == 4:
+        elif n == 4:
             sm.faces.append(1)
         else:
-            continue
+            sm.faces.append(n)
         sm.faces.extend(f)
 
     return [sm]


### PR DESCRIPTION
Closes #56 

Modified ToSpeckle and ToNative mesh conversion to allow for n-gon faces.
Requires some further testing before is ready to merge.

ToSpeckle triangles and quads still use the 0 and 1 cardinality (rather than 3 and 4) at least for now until all our other connectors are updated to accept 3 and 4.
https://github.com/specklesystems/speckle-blender/blob/14aaf4f064cdb0e1c1a52d19132b4d54ccb5f295/bpy_speckle/convert/to_speckle/mesh.py#L34-L42