### PR TITLE
fix(converter): pass brep materials to displayvals

### DIFF
--- a/bpy_speckle/convert/to_speckle.py
+++ b/bpy_speckle/convert/to_speckle.py
@@ -13,7 +13,9 @@ UNITS = "m"
 CAN_CONVERT_TO_SPECKLE = ("MESH", "CURVE", "EMPTY")
 
 
-def convert_to_speckle(blender_object, scale, desgraph=None):
+def convert_to_speckle(blender_object, scale, units, desgraph=None):
+    global UNITS
+    UNITS = units
     blender_type = blender_object.type
     if blender_type not in CAN_CONVERT_TO_SPECKLE:
         return
@@ -69,7 +71,7 @@ def mesh_to_speckle(blender_object, data, scale=1.0):
         faces=[],
         colors=[],
         textureCoordinates=[],
-        units="m" if unit_system == "METRIC" else "ft",
+        units=UNITS,
         bbox=Box(area=0.0, volume=0.0),
     )
 
@@ -274,19 +276,18 @@ def material_to_speckle(blender_object) -> RenderMaterial:
 
 
 def transform_to_speckle(blender_transform, scale=1.0):
-    units = "m" if bpy.context.scene.unit_settings.system == "METRIC" else "ft"
     value = [y for x in blender_transform for y in x]
     # scale the translation
     for i in (3, 7, 11):
         value[i] *= scale
 
-    return Transform(value=value, units=units)
+    return Transform(value=value, units=UNITS)
 
 
 def block_def_to_speckle(blender_definition, scale=1.0):
     geometry = []
     for geo in blender_definition.objects:
-        geometry.extend(convert_to_speckle(geo, scale))
+        geometry.extend(convert_to_speckle(geo, scale, UNITS))
     block_def = BlockDefinition(
         units=UNITS,
         name=blender_definition.name,

--- a/bpy_speckle/operators/object.py
+++ b/bpy_speckle/operators/object.py
@@ -151,9 +151,10 @@ class UploadNgonsAsPolylines(bpy.types.Operator):
             client = speckle_clients[int(context.scene.speckle.active_user)]
             stream = user.streams[user.active_stream]
 
-            scale = context.scene.unit_settings.scale_length / get_scale_length(
-                stream.units
-            )
+            # scale = context.scene.unit_settings.scale_length / get_scale_length(
+            #     stream.units
+            # )
+            scale = 1.0
 
             sp = ngons_to_speckle_polylines(active, scale)
 

--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -374,9 +374,14 @@ class SendStreamObjects(bpy.types.Operator):
 
         client = speckle_clients[int(context.scene.speckle.active_user)]
 
-        scale = context.scene.unit_settings.scale_length / get_scale_length(
-            stream.units.lower()
-        )
+        # scale = context.scene.unit_settings.scale_length / get_scale_length(
+        #     stream.units.lower()
+        # )
+        
+
+        scale = 1.0
+
+        units = "m" if bpy.context.scene.unit_settings.system == "METRIC" else "ft"
 
         """
         Get script from text editor for injection
@@ -411,18 +416,19 @@ class SendStreamObjects(bpy.types.Operator):
 
             _report("Converting {}".format(obj.name))
 
-            ngons = obj.get("speckle_ngons_as_polylines", False)
+            # ngons = obj.get("speckle_ngons_as_polylines", False)
 
-            if ngons:
-                converted = ngons_to_speckle_polylines(obj, scale)
-            else:
-                converted = convert_to_speckle(
-                    obj,
-                    scale,
-                    bpy.context.evaluated_depsgraph_get()
-                    if self.apply_modifiers
-                    else None,
-                )
+            # if ngons:
+            #     converted = ngons_to_speckle_polylines(obj, scale)
+            # else:
+            converted = convert_to_speckle(
+                obj,
+                scale,
+                units,
+                bpy.context.evaluated_depsgraph_get()
+                if self.apply_modifiers
+                else None,
+            )
 
             if not converted:
                 continue

--- a/bpy_speckle/ui/view3d.py
+++ b/bpy_speckle/ui/view3d.py
@@ -230,9 +230,6 @@ class VIEW3D_PT_SpeckleActiveStream(bpy.types.Panel):
 
                 row = col.row(align=True)
                 subcol = row.column()
-                subcol.label(text="Units:")
-                subcol = row.column()
-                subcol.label(text=stream.units)
 
                 col.label(text="Description:")
                 area = col.box()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["izzy lyseggen <izzy.lyseggen@gmail.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7, <4.0.0"
+python = ">=3.8, <4.0.0"
 specklepy = "^2.6.6"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- removes some superficial depreciated units stuff
- passes down brep `renderMaterial` to each item in its `displayValue`