### PR TITLE
ci: blender mac pt 2 electric boogaloo 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
     parameters:
       slug:
         type: string
-        default: ""
+        default: "blender"
       installer:
         type: boolean
         default: false
@@ -208,9 +208,7 @@ workflows:
               only:
                 - main
                 - /ci\/.*/
-
       - build-connector-win:
-          slug: blender
           requires:
             - get-ci-tools
           filters:
@@ -218,9 +216,7 @@ workflows:
               only:
                 - main
                 - /ci\/.*/
-
       - build-connector-mac:
-          slug: blender-mac
           requires:
             - get-ci-tools
           filters:


### PR DESCRIPTION
- build installer for both intel `osx-x64` and m1 `osx-arm64`
- conditionally upgrade py and install dependencies for intel