### PR TITLE
Jrm/receive script update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,30 @@ jobs:
           from: '"speckle-sharp-ci-tools/Installers/"'
           to: s3://speckle-releases/installers/
 
+  deploy-manager2:
+    docker:
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
+    parameters:
+      slug:
+        type: string
+      os:
+        type: string
+      extension:
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Install Manager Feed CLI
+          command: dotnet tool install --global Speckle.Manager.Feed
+      - run:
+          name: Upload new version
+          command: |
+            TAG=$(if [ "${CIRCLE_TAG}" ]; then echo $CIRCLE_TAG; else echo "0.0.0"; fi;)
+            SEMVER=$(echo "$TAG" | sed -e 's/\/[a-zA-Z-]*//')
+            /root/.dotnet/tools/Speckle.Manager.Feed deploy -s << parameters.slug >> -v ${SEMVER} -u https://releases.speckle.dev/installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >> -o << parameters.os >> -f speckle-sharp-ci-tools/Installers/<< parameters.slug >>/<< parameters.slug >>-${SEMVER}.<< parameters.extension >>
+
 workflows:
   build: # build the installers, but don't persist to workspace for deployment
     jobs:
@@ -283,3 +307,16 @@ workflows:
               only: /^(all|win|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
             branches:
               ignore: /.*/
+
+      - deploy-manager2:
+          slug: blender
+          os: Win
+          extension: exe
+          requires:
+            - get-ci-tools
+            - build-deploy-connector-win
+          filters:
+            tags:
+              only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+            branches:
+              ignore: /.*/ # For testing only! /ci\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,45 +266,43 @@ workflows:
             - get-ci-tools
           filters:
             tags:
-              only: /^(all|win)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
             branches:
               ignore: /.*/
 
-      - build-connector-mac:
-          name: build-deploy-connector-mac-arm
-          slug: blender-mac-arm
-          runtime: osx-arm64
-          installer: true
-          requires:
-            - get-ci-tools
-          filters:
-            tags:
-              only: /^(all|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
-            branches:
-              ignore: /.*/
+      # - build-connector-mac:
+      #     name: build-deploy-connector-mac-arm
+      #     slug: blender-mac-arm
+      #     runtime: osx-arm64
+      #     installer: true
+      #     requires:
+      #       - get-ci-tools
+      #     filters:
+      #       tags:
+      #         only: /^(all|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+      #       branches:
+      #         ignore: /.*/
 
-      - build-connector-mac:
-          name: build-deploy-connector-mac-intel
-          slug: blender-mac-intel
-          runtime: osx-x64
-          installer: true
-          requires:
-            - get-ci-tools
-          filters:
-            tags:
-              only: /^(all|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
-            branches:
-              ignore: /.*/
+      # - build-connector-mac:
+      #     name: build-deploy-connector-mac-intel
+      #     slug: blender-mac-intel
+      #     runtime: osx-x64
+      #     installer: true
+      #     requires:
+      #       - get-ci-tools
+      #     filters:
+      #       tags:
+      #         only: /^(all|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+      #       branches:
+      #         ignore: /.*/
 
       - deploy:
           requires:
             - get-ci-tools
             - build-deploy-connector-win
-            - build-deploy-connector-mac-arm
-            - build-deploy-connector-mac-intel
           filters:
             tags:
-              only: /^(all|win|mac)\/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
             branches:
               ignore: /.*/
 
@@ -314,9 +312,9 @@ workflows:
           extension: exe
           requires:
             - get-ci-tools
-            - build-deploy-connector-win
+            - deploy
           filters:
             tags:
-              only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
+              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ workflows:
             - get-ci-tools
           filters:
             tags:
-              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
+              only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
             branches:
               ignore: /.*/
 
@@ -302,7 +302,7 @@ workflows:
             - build-deploy-connector-win
           filters:
             tags:
-              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
+              only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
             branches:
               ignore: /.*/
 
@@ -315,6 +315,6 @@ workflows:
             - deploy
           filters:
             tags:
-              only: /^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-\\w+)?(\\/all)?$/
+              only: /([0-9]+)\.([0-9]+)\.([0-9]+)(?:-\w+)?$/
             branches:
               ignore: /.*/ # For testing only! /ci\/.*/

--- a/bpy_speckle/clients.py
+++ b/bpy_speckle/clients.py
@@ -1,4 +1,7 @@
 """
 Permanent handle on all user clients
 """
-speckle_clients = []
+from specklepy.api.client import SpeckleClient
+
+
+speckle_clients: list[SpeckleClient] = []

--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -1,7 +1,7 @@
 from bpy_speckle.convert.to_native import convert_to_native
+from specklepy.objects.base import Base
 
-
-def get_speckle_subobjects(attr, scale, name):
+def get_speckle_subobjects(attr: dict | Base, scale: float, name: str) -> list:
     subobjects = []
     keys = attr.keys() if isinstance(attr, dict) else attr.get_dynamic_member_names()
     for key in keys:

--- a/bpy_speckle/convert/to_native.py
+++ b/bpy_speckle/convert/to_native.py
@@ -25,7 +25,7 @@ CAN_CONVERT_TO_NATIVE = (
 )
 
 
-def can_convert_to_native(speckle_object):
+def can_convert_to_native(speckle_object: Base) -> bool:
     if type(speckle_object) in CAN_CONVERT_TO_NATIVE:
         return True
     if getattr(
@@ -37,7 +37,7 @@ def can_convert_to_native(speckle_object):
     return False
 
 
-def convert_to_native(speckle_object, name=None):
+def convert_to_native(speckle_object: Base, name: str = None):
     speckle_type = type(speckle_object)
     speckle_name = (
         name
@@ -52,7 +52,7 @@ def convert_to_native(speckle_object, name=None):
         )
         if not elements and not display:
             _report(f"Could not convert unsupported Speckle object: {speckle_object}")
-            return
+            return None
         if isinstance(display, list):
             elements.extend(display)
         else:
@@ -130,7 +130,7 @@ def convert_to_native(speckle_object, name=None):
     return blender_object
 
 
-def mesh_to_native(speckle_mesh: Mesh, name, scale=1.0):
+def mesh_to_native(speckle_mesh: Mesh, name: str, scale=1.0) -> bpy.types.Mesh:
 
     if name in bpy.data.meshes.keys():
         blender_mesh = bpy.data.meshes[name]
@@ -150,7 +150,7 @@ def mesh_to_native(speckle_mesh: Mesh, name, scale=1.0):
 
     return blender_mesh
 
-def line_to_native(speckle_curve, blender_curve, scale):
+def line_to_native(speckle_curve: Line, blender_curve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
     line = blender_curve.splines.new("POLY")
     line.points.add(1)
 
@@ -173,7 +173,7 @@ def line_to_native(speckle_curve, blender_curve, scale):
         return line
 
 
-def polyline_to_native(scurve, bcurve, scale):
+def polyline_to_native(scurve: Polyline, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
     if value := scurve.value:
         N = len(value) // 3
 
@@ -197,7 +197,7 @@ def polyline_to_native(scurve, bcurve, scale):
         return polyline
 
 
-def nurbs_to_native(scurve, bcurve, scale):
+def nurbs_to_native(scurve: Curve, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
     if points := scurve.points:
         N = len(points) // 3
 
@@ -226,12 +226,12 @@ def nurbs_to_native(scurve, bcurve, scale):
         return nurbs
 
 
-def arc_to_native(rcurve, bcurve, scale):
+def arc_to_native(rcurve: Arc, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
     # TODO: improve Blender representation of arc
 
     plane = rcurve.plane
     if not plane:
-        return
+        return None
 
     normal = mathutils.Vector([plane.normal.x, plane.normal.y, plane.normal.z])
 
@@ -288,7 +288,7 @@ def arc_to_native(rcurve, bcurve, scale):
     return arc
 
 
-def polycurve_to_native(scurve, bcurve, scale):
+def polycurve_to_native(scurve: Polycurve, bcurve: bpy.types.Curve, scale: float):
     """
     Convert Polycurve object
     """
@@ -307,7 +307,7 @@ def polycurve_to_native(scurve, bcurve, scale):
     return curves
 
 
-def icurve_to_native_spline(speckle_curve, blender_curve, scale=1.0):
+def icurve_to_native_spline(speckle_curve: Base, blender_curve: bpy.types.Curve, scale=1.0):
     curve_type = type(speckle_curve)
     if curve_type is Line:
         return line_to_native(speckle_curve, blender_curve, scale)
@@ -321,7 +321,7 @@ def icurve_to_native_spline(speckle_curve, blender_curve, scale=1.0):
         return arc_to_native(speckle_curve, blender_curve, scale)
 
 
-def icurve_to_native(speckle_curve, name=None, scale=1.0):
+def icurve_to_native(speckle_curve: Base, name=None, scale=1.0) -> Curve | None:
     curve_type = type(speckle_curve)
     if curve_type not in SUPPORTED_CURVES:
         _report(f"Unsupported curve type: {curve_type}")
@@ -340,7 +340,7 @@ def icurve_to_native(speckle_curve, name=None, scale=1.0):
     return blender_curve
 
 
-def transform_to_native(transform: Transform, scale=1.0):
+def transform_to_native(transform: Transform, scale=1.0) -> mathutils.Matrix:
     mat = mathutils.Matrix(
         [
             transform.value[:4],
@@ -355,7 +355,7 @@ def transform_to_native(transform: Transform, scale=1.0):
     return mat
 
 
-def block_def_to_native(definition: BlockDefinition, scale=1.0):
+def block_def_to_native(definition: BlockDefinition, scale=1.0) -> bpy.types.Collection:
     native_def = bpy.data.collections.get(definition.name)
     if native_def:
         return native_def
@@ -373,7 +373,7 @@ def block_def_to_native(definition: BlockDefinition, scale=1.0):
     return native_def
 
 
-def block_instance_to_native(instance: BlockInstance, scale=1.0):
+def block_instance_to_native(instance: BlockInstance, scale=1.0) -> bpy.types.Object:
     """
     Convert BlockInstance to native
     """

--- a/bpy_speckle/convert/to_native.py
+++ b/bpy_speckle/convert/to_native.py
@@ -4,6 +4,7 @@ import mathutils
 import bpy, bmesh, bpy_types
 from specklepy.objects.other import *
 from specklepy.objects.geometry import *
+from bpy.types import Object
 from .util import (
     add_blender_material,
     add_custom_properties,
@@ -37,7 +38,7 @@ def can_convert_to_native(speckle_object: Base) -> bool:
     return False
 
 
-def convert_to_native(speckle_object: Base, name: str = None):
+def convert_to_native(speckle_object: Base, name: str = None) -> list | Object:
     speckle_type = type(speckle_object)
     speckle_name = (
         name

--- a/bpy_speckle/convert/util.py
+++ b/bpy_speckle/convert/util.py
@@ -1,9 +1,13 @@
+import math
 from typing import Tuple
+from bmesh.types import BMesh
 import bpy, struct, idprop
 
 from specklepy.objects.base import Base
+from specklepy.objects.geometry import Mesh
 from specklepy.serialization.base_object_serializer import BaseObjectSerializer
 from bpy_speckle.functions import _report
+from bpy.types import Object
 
 IGNORED_PROPERTY_KEYS = {
     "id",
@@ -38,7 +42,7 @@ def to_argb_int(diffuse_colour) -> int:
 
     return int.from_bytes(diffuse_colour, byteorder="big", signed=True)
 
-def add_custom_properties(speckle_object, blender_object):
+def add_custom_properties(speckle_object: Base, blender_object: Object):
     if blender_object is None:
         return
 
@@ -69,7 +73,7 @@ def add_custom_properties(speckle_object, blender_object):
                     blender_object[k] = v            
 
 
-def add_blender_material(speckle_object, blender_object) -> None:
+def add_blender_material(speckle_object: Base, blender_object: Object) -> None:
     """Add material to a blender object if the corresponding speckle object has a render material"""
     if blender_object.data is None:
         return
@@ -107,7 +111,7 @@ def add_blender_material(speckle_object, blender_object) -> None:
     blender_object.data.materials.append(blender_mat)
 
 
-def add_vertices(speckle_mesh, blender_mesh, scale=1.0):
+def add_vertices(speckle_mesh: Mesh, blender_mesh: BMesh, scale=1.0):
     sverts = speckle_mesh.vertices
 
     if sverts and len(sverts) > 0:
@@ -123,7 +127,7 @@ def add_vertices(speckle_mesh, blender_mesh, scale=1.0):
     blender_mesh.verts.ensure_lookup_table()
 
 
-def add_faces(speckle_mesh, blender_mesh, smooth=False):
+def add_faces(speckle_mesh: Mesh, blender_mesh: BMesh, smooth=False):
     sfaces = speckle_mesh.faces
 
     if sfaces and len(sfaces) > 0:
@@ -147,7 +151,7 @@ def add_faces(speckle_mesh, blender_mesh, smooth=False):
         blender_mesh.verts.index_update()
 
 
-def add_colors(speckle_mesh, blender_mesh):
+def add_colors(speckle_mesh: Mesh, blender_mesh: BMesh):
 
     scolors = speckle_mesh.colors
 
@@ -178,7 +182,7 @@ def add_colors(speckle_mesh, blender_mesh):
                     loop[color_layer] = colors[loop.vert.index]
 
 
-def add_uv_coords(speckle_mesh, blender_mesh):
+def add_uv_coords(speckle_mesh: Mesh, blender_mesh: BMesh):
     s_uvs = speckle_mesh.textureCoordinates
     if not s_uvs:
         return

--- a/bpy_speckle/functions.py
+++ b/bpy_speckle/functions.py
@@ -33,7 +33,7 @@ def _report(msg):
     print("SpeckleBlender: {}".format(msg))
 
 
-def get_scale_length(units):
+def get_scale_length(units: str) -> float:
     if units.lower() in unit_scale.keys():
         return unit_scale[units]
     _report("Units <{}> are not supported.".format(units))

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -5,6 +5,7 @@ import bpy
 from bpy_speckle.functions import _report
 from bpy_speckle.clients import speckle_clients
 from specklepy.api.client import SpeckleClient
+from specklepy.api.models import Stream, User
 from specklepy.api.credentials import get_local_accounts
 from datetime import datetime
 
@@ -59,7 +60,7 @@ class LoadUsers(bpy.types.Operator):
         return {"FINISHED"}
 
 
-def add_user_stream(user, stream):
+def add_user_stream(user: User, stream: Stream):
     s = user.streams.add()
     s.name = stream.name
     s.id = stream.id


### PR DESCRIPTION
closes #114 

Implements `execute_for_each` and `execute_for_all` functions

The user can specify a receive script (any user python text file) with call back functions that match the name (and number of parameters) as below:
```py
def execute_for_each(context, blenderObject, speckleObject):
    '''
    Executed once per object, immediatly after each object is converted
    
    :param scene: blender context
    :type context: bpy.types.Context
    :param blenderObject: converted blender object
    :type blenderObject: bpy.types.Object
    :param speckleObject: The speckle object which was converted
    :type speckleObject: specklepy.objects.Base
    :rtype: bpy.types.Object | None
    :return: The blender object to be added to the scene
    '''
    # Can modify the blenderObject here
    # E.g. Attaching extra properties (using the speckleObject) 
    # E.g. Conditionaly ignoring certain objects (return None)
    # E.g. Performing other modifications/custom conversion logic
    
    # Must return the object for it to be added to the scene
    return blenderObject
    
    
def execute_for_all(context, objects):
    '''
    Executed once per recieve operation, immediatly after all objects have been converted
    
    :param context: blender context
    :type context: bpy.types.Context
    :param objects: dictionary of object name to object
    :type objects: dict[str, bpy.types.Object]
    '''
    # For example, You can use this to perform bpy.ops on all recieved meshes
    # Or any custom behaviour you want with the given parameters
```

the old `execute(scene, blenderObject)` function will still be called (if no `execute_for_each` function is specified) to retain backwards compatibility with older scripts.

Before merge:
 - [x] ~~Are we happy with `execute_for_each` using `scene` not `context`, it's what the old one used, but why?~~ Now using context
 - [x] ~~Are we happy with the naming of these functions (just noticed #114 specifies different names)~~ happy
 - [x] ~~Do we want `Clean Meshes` to be a receive script that we bundle with our add-on (need to figure out the best way to bundle it)~~. For now, no
 - [ ] Should we do something similar for Send scripts (they would now be somewhat unaligned), are there usecases?
