### PR TITLE
Fixed issue with connector failing to load on Blender 2.93

### DIFF
--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -1,7 +1,8 @@
+from typing import Union
 from bpy_speckle.convert.to_native import convert_to_native
 from specklepy.objects.base import Base
 
-def get_speckle_subobjects(attr: dict | Base, scale: float, name: str) -> list:
+def get_speckle_subobjects(attr: Union[dict, Base], scale: float, name: str) -> list:
     subobjects = []
     keys = attr.keys() if isinstance(attr, dict) else attr.get_dynamic_member_names()
     for key in keys:

--- a/bpy_speckle/convert/to_native.py
+++ b/bpy_speckle/convert/to_native.py
@@ -1,4 +1,5 @@
 import math
+from typing import Union
 from bpy_speckle.functions import get_scale_length, _report
 import mathutils
 import bpy, bmesh, bpy_types
@@ -38,7 +39,7 @@ def can_convert_to_native(speckle_object: Base) -> bool:
     return False
 
 
-def convert_to_native(speckle_object: Base, name: str = None) -> list | Object | None:
+def convert_to_native(speckle_object: Base, name: Optional[str] = None) -> Optional[Union[list, Object]]:
     speckle_type = type(speckle_object)
     speckle_name = (
         name
@@ -63,7 +64,7 @@ def convert_to_native(speckle_object: Base, name: str = None) -> list | Object |
         # not making it hidden, so it will get added on send as i think it might be helpful? can reconsider
         converted = []
         for item in elements:
-            if(item is None):
+            if not isinstance(item, Base):
                 continue
             item.parent_speckle_type = speckle_object.speckle_type
             blender_object = convert_to_native(item)
@@ -154,7 +155,7 @@ def mesh_to_native(speckle_mesh: Mesh, name: str, scale=1.0) -> bpy.types.Mesh:
 
     return blender_mesh
 
-def line_to_native(speckle_curve: Line, blender_curve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
+def line_to_native(speckle_curve: Line, blender_curve: bpy.types.Curve, scale: float) -> Optional[bpy.types.Spline]:
     line = blender_curve.splines.new("POLY")
     line.points.add(1)
 
@@ -177,7 +178,7 @@ def line_to_native(speckle_curve: Line, blender_curve: bpy.types.Curve, scale: f
         return line
 
 
-def polyline_to_native(scurve: Polyline, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
+def polyline_to_native(scurve: Polyline, bcurve: bpy.types.Curve, scale: float) -> Optional[bpy.types.Spline]:
     if value := scurve.value:
         N = len(value) // 3
 
@@ -201,7 +202,7 @@ def polyline_to_native(scurve: Polyline, bcurve: bpy.types.Curve, scale: float) 
         return polyline
 
 
-def nurbs_to_native(scurve: Curve, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
+def nurbs_to_native(scurve: Curve, bcurve: bpy.types.Curve, scale: float) -> Optional[bpy.types.Spline]:
     if points := scurve.points:
         N = len(points) // 3
 
@@ -230,7 +231,7 @@ def nurbs_to_native(scurve: Curve, bcurve: bpy.types.Curve, scale: float) -> bpy
         return nurbs
 
 
-def arc_to_native(rcurve: Arc, bcurve: bpy.types.Curve, scale: float) -> bpy.types.Spline | None:
+def arc_to_native(rcurve: Arc, bcurve: bpy.types.Curve, scale: float) -> Optional[bpy.types.Spline]:
     # TODO: improve Blender representation of arc
 
     plane = rcurve.plane
@@ -325,7 +326,7 @@ def icurve_to_native_spline(speckle_curve: Base, blender_curve: bpy.types.Curve,
         return arc_to_native(speckle_curve, blender_curve, scale)
 
 
-def icurve_to_native(speckle_curve: Base, name=None, scale=1.0) -> Curve | None:
+def icurve_to_native(speckle_curve: Base, name=None, scale=1.0) -> Optional[Curve]:
     curve_type = type(speckle_curve)
     if curve_type not in SUPPORTED_CURVES:
         _report(f"Unsupported curve type: {curve_type}")

--- a/bpy_speckle/convert/to_speckle.py
+++ b/bpy_speckle/convert/to_speckle.py
@@ -1,5 +1,6 @@
+from typing import Optional
 import bpy
-from bpy.types import MeshVertColor, MeshVertex, Object
+from bpy.types import Depsgraph, MeshVertColor, MeshVertex, Object
 from specklepy.objects.geometry import Mesh, Curve, Interval, Box, Point, Polyline
 from specklepy.objects.other import *
 from bpy_speckle.functions import _report
@@ -14,7 +15,7 @@ UNITS = "m"
 CAN_CONVERT_TO_SPECKLE = ("MESH", "CURVE", "EMPTY")
 
 
-def convert_to_speckle(blender_object: Object, scale: float, units: str, desgraph=None) -> list | None:
+def convert_to_speckle(blender_object: Object, scale: float, units: str, desgraph: Optional[Depsgraph]) -> Optional[list]:
     global UNITS
     UNITS = units
     blender_type = blender_object.type
@@ -100,7 +101,7 @@ def mesh_to_speckle(blender_object: Object, data: bpy.types.Mesh, scale=1.0) -> 
     return [sm]
 
 
-def bezier_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name:str = None) -> Curve:
+def bezier_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name: Optional[str] = None) -> Curve:
     degree = 3
     closed = spline.use_cyclic_u
 
@@ -149,7 +150,7 @@ def bezier_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: floa
     )
 
 
-def nurbs_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name:str = None) -> Curve:
+def nurbs_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name: Optional[str] = None) -> Curve:
     knots = make_knots(spline)
     points = [tuple(matrix @ pt.co.xyz * scale) for pt in spline.points]
     degree = spline.order_u - 1
@@ -175,7 +176,7 @@ def nurbs_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float
     )
 
 
-def poly_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name: str = None) -> Polyline:
+def poly_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float, name: Optional[str] = None) -> Polyline:
     points = [tuple(matrix @ pt.co.xyz * scale) for pt in spline.points]
 
     length = spline.calc_length()
@@ -192,7 +193,7 @@ def poly_to_speckle(matrix: List[float], spline: bpy.types.Spline, scale: float,
     )
 
 
-def icurve_to_speckle(blender_object: Object, data: bpy.types.Curve, scale=1.0) -> List[Base] | None:
+def icurve_to_speckle(blender_object: Object, data: bpy.types.Curve, scale=1.0) -> Optional[List[Base]]:
     UNITS = "m" if bpy.context.scene.unit_settings.system == "METRIC" else "ft"
 
     if blender_object.type != "CURVE":
@@ -221,7 +222,7 @@ def icurve_to_speckle(blender_object: Object, data: bpy.types.Curve, scale=1.0) 
     return curves
 
 
-def ngons_to_speckle_polylines(blender_object: Object, data: bpy.types.Mesh, scale=1.0) -> List[Polyline] | None:
+def ngons_to_speckle_polylines(blender_object: Object, data: bpy.types.Mesh, scale=1.0) -> Optional[List[Polyline]]:
     UNITS = "m" if bpy.context.scene.unit_settings.system == "METRIC" else "ft"
 
     if blender_object.type != "MESH":
@@ -253,7 +254,7 @@ def ngons_to_speckle_polylines(blender_object: Object, data: bpy.types.Mesh, sca
     return polylines
 
 
-def material_to_speckle(blender_object: Object) -> RenderMaterial | None:
+def material_to_speckle(blender_object: Object) -> Optional[RenderMaterial]:
     """Create and return a render material from a blender object"""
     if not getattr(blender_object.data, "materials", None):
         return None
@@ -318,7 +319,7 @@ def block_instance_to_speckle(blender_instance: Object, scale=1.0):
     )
 
 
-def empty_to_speckle(blender_object: Object, scale=1.0) -> BlockInstance | None:
+def empty_to_speckle(blender_object: Object, scale=1.0) -> Optional[BlockInstance]:
     # probably an instance collection (block) so let's try it
     try:
         geo = blender_object.instance_collection.objects.items()

--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -96,8 +96,8 @@ def get_objects_collections_recursive(base: Base, parent_col: bpy.types.Collecti
     return objects
 
 
-ObjectCallback = Callable[[bpy.types.Context, Object, Base], Object] | None
-ReceiveCompleteCallback = Callable[[bpy.types.Context, Dict[str, Object]], None] | None
+ObjectCallback = Optional[Callable[[bpy.types.Context, Object, Base], Object]]
+ReceiveCompleteCallback = Optional[Callable[[bpy.types.Context, Dict[str, Object]], None]]
 
 def get_receive_funcs(context: Context, created_objects: Dict[str, Object]) -> tuple[ObjectCallback, ReceiveCompleteCallback]:
         """


### PR DESCRIPTION
closes #126
Issue was due to me using type hinting syntax that that's unsupported in python 3.9 (what Blender 2.93 uses)