### PR TITLE
deprecated delete stream

### DIFF
--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -584,6 +584,7 @@ class CreateStream(bpy.types.Operator):
         )
 
 
+@deprecated
 class DeleteStream(bpy.types.Operator):
     """
     Delete stream
@@ -596,6 +597,7 @@ class DeleteStream(bpy.types.Operator):
 
     are_you_sure: BoolProperty(
         name="Confirm",
+        description="⚠ This action will delete your entire stream permanently ⚠",
         default=False,
     ) # type: ignore 
 

--- a/bpy_speckle/ui/view3d.py
+++ b/bpy_speckle/ui/view3d.py
@@ -149,7 +149,6 @@ class VIEW3D_PT_SpeckleStreams(bpy.types.Panel):
             row = col.row(align=True)
             row.operator("speckle.add_stream_from_url", text="", icon="URL")
             row.operator("speckle.create_stream", text="", icon="ADD")
-            row.operator("speckle.delete_stream", text="", icon="REMOVE")
             row.operator("speckle.load_user_streams", text="", icon="FILE_REFRESH")
 
 
@@ -225,7 +224,6 @@ class VIEW3D_PT_SpeckleActiveStream(bpy.types.Panel):
                 subcol = row.column()
                 subcol.operator("speckle.send_stream_objects", text="Send")
                 subcol.prop(speckle, "send_script", text="")
-                area.prop(stream, "query", text="Filter")
 
                 col.separator()
 


### PR DESCRIPTION
We offer a feature of the Blender UI to delete streams
![image](https://github.com/specklesystems/speckle-blender/assets/45512892/1aab264b-9dcd-474c-80c9-e944045cc8fb)
And we do require the user to confirm that selection
![image](https://github.com/specklesystems/speckle-blender/assets/45512892/abb258fe-14f2-4622-9d06-e04aea72c5a0)

But this feature is quite dangerous, and I'm concerned its too easy to delete the wrong project or users misunderstand that this deletes the entire project permanently