### PR TITLE
Recover branch selection

### DIFF
--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -6,7 +6,7 @@ import bpy
 from bpy.types import Context
 from bpy_speckle.functions import _report
 from bpy_speckle.clients import speckle_clients
-from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, SelectionStateHack
+from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, restore_selection_state
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.models import Stream
 from specklepy.core.api.credentials import get_local_accounts, Account
@@ -202,7 +202,7 @@ class LoadUserStreams(bpy.types.Operator):
             sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
             add_user_stream(user, sstream)
 
-        SelectionStateHack.restore_selection_state(speckle)
+        restore_selection_state(speckle)
 
         bpy.context.view_layer.update()
 

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -6,7 +6,7 @@ import bpy
 from bpy.types import Context
 from bpy_speckle.functions import _report
 from bpy_speckle.clients import speckle_clients
-from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle
+from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, SelectedBranchHack
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.models import Stream
 from specklepy.core.api.credentials import get_local_accounts, Account
@@ -201,6 +201,10 @@ class LoadUserStreams(bpy.types.Operator):
             assert(s.id)
             sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
             add_user_stream(user, sstream)
+
+        if SelectedBranchHack.selected_branch != None:
+            active_stream = speckle.get_active_user().get_active_stream()
+            active_stream.branch = str(SelectedBranchHack.selected_branch)
 
         bpy.context.view_layer.update()
 

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -6,7 +6,7 @@ import bpy
 from bpy.types import Context
 from bpy_speckle.functions import _report
 from bpy_speckle.clients import speckle_clients
-from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, SelectedBranchHack
+from bpy_speckle.properties.scene import SpeckleBranchObject, SpeckleCommitObject, SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, SelectionStateHack
 from specklepy.core.api.client import SpeckleClient
 from specklepy.core.api.models import Stream
 from specklepy.core.api.credentials import get_local_accounts, Account
@@ -202,9 +202,7 @@ class LoadUserStreams(bpy.types.Operator):
             sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
             add_user_stream(user, sstream)
 
-        if SelectedBranchHack.selected_branch != None:
-            active_stream = speckle.get_active_user().get_active_stream()
-            active_stream.branch = str(SelectedBranchHack.selected_branch)
+        SelectionStateHack.restore_selection_state(speckle)
 
         bpy.context.view_layer.update()
 

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -25,6 +25,12 @@ class SelectionStateHack:
             if index == selected_index:
                 return item.id
         return None
+    
+    @staticmethod
+    def get_item_index_by_id(collection, id):
+        for index, item in enumerate(collection):
+            if item.id == id:
+                return str(index)
 
     @staticmethod
     def restore_selection_state(speckle):
@@ -35,10 +41,8 @@ class SelectionStateHack:
             same_user = active_user.id == SelectionStateHack.selected_user_id
             same_stream = active_stream.id == SelectionStateHack.selected_stream_id
             if same_user and same_stream:
-                for index, branch in enumerate(active_stream.branches):
-                    if branch.id == SelectionStateHack.selected_branch_id:
-                        active_stream.branch = str(index)
-                        break
+                if branch := SelectionStateHack.get_item_index_by_id(active_stream.branches, SelectionStateHack.selected_branch_id):
+                    active_stream.branch = branch
         
         # Restore commit selection state
         if SelectionStateHack.selected_commit_id != None:
@@ -49,10 +53,8 @@ class SelectionStateHack:
             same_stream = active_stream.id == SelectionStateHack.selected_stream_id
             same_branch = active_branch.id == SelectionStateHack.selected_branch_id
             if same_user and same_stream and same_branch:
-                for index, commit in enumerate(active_branch.commits):
-                    if commit.id == SelectionStateHack.selected_commit_id:
-                        active_branch.commit = str(index)
-                        break
+                if commit := SelectionStateHack.get_item_index_by_id(active_branch.commits, SelectionStateHack.selected_commit_id):
+                    active_branch.commit = commit
 
 class SpeckleSceneObject(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty(default="") # type: ignore

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -80,13 +80,12 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
     ) # type: ignore
 
     def get_active_branch(self) -> Optional[SpeckleBranchObject]:
-        if SelectedBranchHack.selected_branch != None:
-            return self.branches[SelectedBranchHack.selected_branch]
         selected_index = int(self.branch)
+        if SelectedBranchHack.selected_branch != None:
+            selected_index = SelectedBranchHack.selected_branch
         if 0 <= selected_index < len(self.branches): 
             return self.branches[selected_index]
         return None
-
 
 class SpeckleUserObject(bpy.types.PropertyGroup):
     server_name: StringProperty(default="SpeckleXYZ") # type: ignore

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -51,7 +51,9 @@ class SpeckleBranchObject(bpy.types.PropertyGroup):
             return self.commits[selected_index]
         return None
 
-
+class SelectedBranchHack:
+    selected_branch : int = None
+    
 class SpeckleStreamObject(bpy.types.PropertyGroup):
     def get_branches(self, context):
         if self.branches:
@@ -62,6 +64,9 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
                 if branch.name != "globals"
             ]
         return [("0", "<none>", "<none>", 0)]
+    
+    def branch_update_hook(self, context: bpy.types.Context):
+        SelectedBranchHack.selected_branch = int(self.branch)
 
     name: StringProperty(default="") # type: ignore
     description: StringProperty(default="") # type: ignore
@@ -71,9 +76,12 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
         name="Model",
         description="Selected Model",
         items=get_branches,
+        update=branch_update_hook,
     ) # type: ignore
 
     def get_active_branch(self) -> Optional[SpeckleBranchObject]:
+        if SelectedBranchHack.selected_branch != None:
+            return self.branches[SelectedBranchHack.selected_branch]
         selected_index = int(self.branch)
         if 0 <= selected_index < len(self.branches): 
             return self.branches[selected_index]
@@ -153,6 +161,8 @@ class SpeckleSceneSettings(bpy.types.PropertyGroup):
     ) # type: ignore
 
     def get_active_user(self) -> Optional[SpeckleUserObject]:
+        if not self.active_user:
+            return None
         selected_index = int(self.active_user)
         if 0 <= selected_index < len(self.users):
             return self.users[selected_index]


### PR DESCRIPTION
When user refreshes the stream, branch selection resets. As a workaround, I stored selected branch in a class member. Then used that value to get active branch. Better solutions are possible of course.
