### PR TITLE
Skip installing dependencies after initial install

### DIFF
--- a/bpy_speckle/installer.py
+++ b/bpy_speckle/installer.py
@@ -147,10 +147,20 @@ def install_requirements(host_application: str) -> None:
     # script path. Here we'll install the
     # dependencies
     path = connector_installation_path(host_application)
-    print(f"Installing Speckle dependencies to {path}")
+
+    print(path)
 
     from subprocess import run
 
+    def debugger_is_active() -> bool:
+        """Return if the debugger is currently active"""
+        return hasattr(sys, 'gettrace') and sys.gettrace() is not None
+    
+    if not debugger_is_active() and os.listdir(path):
+        print("Skipped installing dependencies")
+        return
+
+    print(f"Installing Speckle dependencies to {path}")
     completed_process = run(
         [
             PYTHON_PATH,

--- a/bpy_speckle/installer.py
+++ b/bpy_speckle/installer.py
@@ -154,7 +154,11 @@ def install_requirements(host_application: str) -> None:
         """Return if the debugger is currently active"""
         return hasattr(sys, 'gettrace') and sys.gettrace() is not None
     
-    if not debugger_is_active() and os.listdir(path):
+    requirements_path = Path(Path(__file__).parent, "requirements.txt")
+
+    is_debug = debugger_is_active()
+    
+    if not is_debug and not requirements_path.exists():
         print("Skipped installing dependencies")
         return
 
@@ -173,7 +177,7 @@ def install_requirements(host_application: str) -> None:
             "-t",
             str(path),
             "-r",
-            str(get_requirements_path()),
+            str(requirements_path),
         ],
         capture_output=True,
         text=True,
@@ -183,6 +187,11 @@ def install_requirements(host_application: str) -> None:
         m = f"Failed to install dependenices through pip, got {completed_process.returncode} return code"
         print(m)
         raise Exception(m)
+    
+    print("Successfully installed dependencies")
+
+    if not is_debug:
+        requirements_path.unlink()
 
 
 def install_dependencies(host_application: str) -> None:

--- a/bpy_speckle/installer.py
+++ b/bpy_speckle/installer.py
@@ -148,8 +148,6 @@ def install_requirements(host_application: str) -> None:
     # dependencies
     path = connector_installation_path(host_application)
 
-    print(path)
-
     from subprocess import run
 
     def debugger_is_active() -> bool:


### PR DESCRIPTION
This PR solves slowness on Blender startup.
Removes requirements file after initial installation.
Skips installing dependencies if requirements file is not found.
Always install dependencies when debugger is detected.