### PR TITLE
Lazy loading for stream branches & commits

### DIFF
--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -195,12 +195,20 @@ class LoadUserStreams(bpy.types.Operator):
             _report("Zero projects found")
             return
 
+
+        active_stream_id = None
+        if active_stream := user.get_active_stream():
+            active_stream_id = active_stream.id
+
         user.streams.clear()
 
         for s in streams:
             assert(s.id)
-            sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
-            add_user_stream(user, sstream)
+            if s.id == active_stream_id:
+                sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
+                add_user_stream(user, sstream)
+            else:
+                add_user_stream(user, s)
 
         restore_selection_state(speckle)
 

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -181,6 +181,7 @@ class LoadUserStreams(bpy.types.Operator):
 
         
     def load_user_stream(self, context: Context) -> None:
+        print("load user stream")
         speckle = get_speckle(context)
 
         user = speckle.validate_user_selection()
@@ -198,13 +199,18 @@ class LoadUserStreams(bpy.types.Operator):
 
         active_stream_id = None
         if active_stream := user.get_active_stream():
+            print("active stream is", active_stream.name)
             active_stream_id = active_stream.id
+        elif len(user.streams) > 0:
+            print("initial active stream is", user.streams[0].name)
+            active_stream_id = user.streams[0].id
 
         user.streams.clear()
 
-        for s in streams:
+        for i, s in enumerate(streams):
             assert(s.id)
-            if s.id == active_stream_id:
+            load_branches = s.id == active_stream_id if active_stream_id else i == 0
+            if load_branches:
                 sstream = client.stream.get(id=s.id, branch_limit=self.branch_limit, commit_limit=10)
                 add_user_stream(user, sstream)
             else:

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -121,7 +121,8 @@ class SpeckleUserObject(bpy.types.PropertyGroup):
         stream = SelectionState.get_item_by_index(self.streams, self.active_stream)
         selection_state.selected_stream_id = stream.id
         selection_state.selected_commit_id = None
-        self.load_stream_branches(context, stream)
+        if len(stream.branches) == 0: # do not reload on selection, same as the old behavior 
+            self.load_stream_branches(context, stream)
 
     server_name: StringProperty(default="SpeckleXYZ") # type: ignore
     server_url: StringProperty(default="https://speckle.xyz") # type: ignore
@@ -254,20 +255,15 @@ class SelectionState:
 
     @staticmethod
     def get_item_id_by_index(collection: bpy.types.PropertyGroup, index: Union[str, int]) -> Optional[str]:
-        # print(list(collection.items()))
-        selected_index = int(index)
-        for index, (_, item) in enumerate(collection.items()):
-            if index == selected_index:
-                return item.id
-        return None
+        if item := SelectionState.get_item_by_index(collection, index):
+            return item.id
     
     @staticmethod
     def get_item_by_index(collection: bpy.types.PropertyGroup, index: Union[str, int]) -> Optional[bpy.types.PropertyGroup]:
-        # print(list(collection.items()))
-        selected_index = int(index)
-        for index, (_, item) in enumerate(collection.items()):
-            if index == selected_index:
-                return item
+        items = collection.values()
+        i = int(index)
+        if 0 <= i <= len(items):
+            return items[i]
         return None
     
     @staticmethod

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -40,6 +40,7 @@ class SpeckleBranchObject(bpy.types.PropertyGroup):
   
     def commit_update_hook(self, context: bpy.types.Context):
         selection_state.selected_commit_id = SelectionState.get_item_id_by_index(self.commits, self.commit)
+        selection_state.selected_branch_id = self.id
 
     name: StringProperty(default="main") # type: ignore
     id: StringProperty(default="") # type: ignore


### PR DESCRIPTION
- Load branches only for default selected stream on initial load user
- Load branches for selected stream on stream selection
- Stream selection does not reload (same as the old behavior)
- Reload only reloads selected stream (is it ok?)
- Fix commit selection reload bug on default selected branch (unrelated bugfix)