### PR TITLE
fix send stream object cases

### DIFF
--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -33,7 +33,7 @@ from bpy_speckle.functions import (
 )
 from bpy_speckle.clients import speckle_clients
 from bpy_speckle.operators.users import LoadUserStreams, add_user_stream
-from bpy_speckle.properties.scene import SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle
+from bpy_speckle.properties.scene import SpeckleSceneSettings, SpeckleStreamObject, SpeckleUserObject, get_speckle, selection_state
 from bpy_speckle.convert.util import ConversionSkippedException, add_to_hierarchy
 from specklepy.core.api.models import Commit
 from specklepy.core.api import operations, host_applications
@@ -285,6 +285,7 @@ class SendStreamObjects(bpy.types.Operator):
         return {"FINISHED"}
 
     def send(self, context: Context) -> None:
+        print("SendStreamObjects")
 
         selected = context.selected_objects
         if len(selected) < 1:
@@ -379,6 +380,11 @@ class SendStreamObjects(bpy.types.Operator):
             sent_url = f"{user.server_url}/streams/{stream.id}/commits/{COMMIT_ID}"
 
         _report(f"Commit Created {sent_url}")
+
+        selection_state.selected_commit_id = COMMIT_ID
+        selection_state.selected_branch_id = branch.id
+        selection_state.selected_stream_id = stream.id
+        selection_state.selected_user_id = user.id
 
         bpy.ops.speckle.load_user_streams() # refresh loaded commits
         context.view_layer.update()

--- a/bpy_speckle/operators/streams.py
+++ b/bpy_speckle/operators/streams.py
@@ -285,7 +285,6 @@ class SendStreamObjects(bpy.types.Operator):
         return {"FINISHED"}
 
     def send(self, context: Context) -> None:
-        print("SendStreamObjects")
 
         selected = context.selected_objects
         if len(selected) < 1:

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -161,7 +161,6 @@ class LoadUserStreams(bpy.types.Operator):
 
         
     def load_user_stream(self, context: Context) -> None:
-        print("LoadUserStreams")
         speckle = get_speckle(context)
 
         user = speckle.validate_user_selection()

--- a/bpy_speckle/operators/users.py
+++ b/bpy_speckle/operators/users.py
@@ -161,6 +161,7 @@ class LoadUserStreams(bpy.types.Operator):
 
         
     def load_user_stream(self, context: Context) -> None:
+        print("LoadUserStreams")
         speckle = get_speckle(context)
 
         user = speckle.validate_user_selection()

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -300,12 +300,7 @@ def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
     
     # Restore commit selection state
     if selection_state.selected_commit_id != None:
-        (active_user, active_stream) = speckle.validate_stream_selection()
-
-        active_branch = active_stream.get_active_branch()
-
-        if active_branch is None:
-            active_branch = active_stream.branches[0]
+        (active_user, active_stream, active_branch) = speckle.validate_branch_selection()
         # print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}, {active_branch.id=}")
         # print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
 

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -40,10 +40,9 @@ class SpeckleBranchObject(bpy.types.PropertyGroup):
         return [("0", "<none>", "<none>", 0)]
   
     def commit_update_hook(self, context: bpy.types.Context):
-        print("commit_update_hook")
         selection_state.selected_commit_id = SelectionState.get_item_id_by_index(self.commits, self.commit)
         selection_state.selected_branch_id = self.id
-        print(f"commit_update_hook: {selection_state.selected_commit_id=}, {selection_state.selected_branch_id=}")
+        # print(f"commit_update_hook: {selection_state.selected_commit_id=}, {selection_state.selected_branch_id=}")
 
     name: StringProperty(default="main") # type: ignore
     id: StringProperty(default="") # type: ignore
@@ -96,10 +95,9 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
         return [("0", "<none>", "<none>", 0)]
     
     def branch_update_hook(self, context: bpy.types.Context):
-        print("branch_update_hook")
         selection_state.selected_branch_id = SelectionState.get_item_id_by_index(self.branches, self.branch)
         selection_state.selected_stream_id = self.id
-        print(f"branch_update_hook: {selection_state.selected_branch_id=}, {selection_state.selected_stream_id=}")
+        # print(f"branch_update_hook: {selection_state.selected_branch_id=}, {selection_state.selected_stream_id=}")
 
     name: StringProperty(default="") # type: ignore
     description: StringProperty(default="") # type: ignore
@@ -126,11 +124,10 @@ class SpeckleUserObject(bpy.types.PropertyGroup):
         stream.load_stream_branches(sstream)
 
     def stream_update_hook(self, context: bpy.types.Context):
-        print("stream_update_hook")
         stream = SelectionState.get_item_by_index(self.streams, self.active_stream)
         selection_state.selected_stream_id = stream.id
         selection_state.selected_user_id = self.id
-        print(f"stream_update_hook: {selection_state.selected_stream_id=}, {selection_state.selected_user_id=}")
+        # print(f"stream_update_hook: {selection_state.selected_stream_id=}, {selection_state.selected_user_id=}")
         if len(stream.branches) == 0: # do not reload on selection, same as the old behavior 
             self.fetch_stream_branches(context, stream)
 
@@ -287,35 +284,30 @@ class SelectionState:
 selection_state = SelectionState()
 
 def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
-    print("restore_selection_state")
     # Restore branch selection state
     if selection_state.selected_branch_id != None:
-        print("restore_selection_state: branch")
         (active_user, active_stream) = speckle.validate_stream_selection()
-        print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}")
-        print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
+        # print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}")
+        # print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
 
         is_same_user = active_user.id == selection_state.selected_user_id
     
         if is_same_user:
-            print("restore_selection_state: branch: same user")
             active_user.active_stream = int(SelectionState.get_item_index_by_id(active_user.streams, selection_state.selected_stream_id))
             active_stream = SelectionState.get_item_by_index(active_user.streams, active_user.active_stream)
             if branch := SelectionState.get_item_index_by_id(active_stream.branches, selection_state.selected_branch_id):
-                print("restore_selection_state: found branch")
                 active_stream.branch = branch
     
     # Restore commit selection state
     if selection_state.selected_commit_id != None:
-        print("restore_selection_state: commit")
         (active_user, active_stream) = speckle.validate_stream_selection()
 
         active_branch = active_stream.get_active_branch()
 
         if active_branch is None:
             active_branch = active_stream.branches[0]
-        print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}, {active_branch.id=}")
-        print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
+        # print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}, {active_branch.id=}")
+        # print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
 
         is_same_user = active_user.id == selection_state.selected_user_id
         is_same_stream = active_stream.id == selection_state.selected_stream_id
@@ -325,10 +317,8 @@ def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
             if commit := SelectionState.get_item_index_by_id(active_branch.commits, selection_state.selected_commit_id):
                 active_branch.commit = commit
 
-    print("restore_selection_state: save")
     (active_user, active_stream, active_branch, active_commit) = speckle.validate_commit_selection()
     # selection_state.selected_user_id = active_user.id
     # selection_state.selected_stream_id = active_stream.id
     selection_state.selected_branch_id = active_branch.id
     selection_state.selected_commit_id = active_commit.id
-    print("restore_selection_state: done")

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -96,7 +96,6 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
     
     def branch_update_hook(self, context: bpy.types.Context):
         selection_state.selected_branch_id = SelectionState.get_item_id_by_index(self.branches, self.branch)
-        selection_state.selected_stream_id = self.id
         # print(f"branch_update_hook: {selection_state.selected_branch_id=}, {selection_state.selected_stream_id=}")
 
     name: StringProperty(default="") # type: ignore
@@ -126,7 +125,6 @@ class SpeckleUserObject(bpy.types.PropertyGroup):
     def stream_update_hook(self, context: bpy.types.Context):
         stream = SelectionState.get_item_by_index(self.streams, self.active_stream)
         selection_state.selected_stream_id = stream.id
-        selection_state.selected_user_id = self.id
         # print(f"stream_update_hook: {selection_state.selected_stream_id=}, {selection_state.selected_user_id=}")
         if len(stream.branches) == 0: # do not reload on selection, same as the old behavior 
             self.fetch_stream_branches(context, stream)

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -309,9 +309,3 @@ def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
         if is_same_user and is_same_stream and is_same_branch:
             if commit := SelectionState.get_item_index_by_id(active_branch.commits, selection_state.selected_commit_id):
                 active_branch.commit = commit
-
-    (active_user, active_stream, active_branch, active_commit) = speckle.validate_commit_selection()
-    # selection_state.selected_user_id = active_user.id
-    # selection_state.selected_stream_id = active_stream.id
-    selection_state.selected_branch_id = active_branch.id
-    selection_state.selected_commit_id = active_commit.id

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -167,7 +167,7 @@ class SpeckleSceneSettings(bpy.types.PropertyGroup):
             for i, user in enumerate(USERS)
         ]
 
-    def set_user(self, context):
+    def user_update_hook(self, context):
         bpy.ops.speckle.load_user_streams() # type: ignore
         selection_state.selected_user_id = SelectionState.get_item_id_by_index(self.users, self.active_user)
 
@@ -175,7 +175,7 @@ class SpeckleSceneSettings(bpy.types.PropertyGroup):
         items=get_users,
         name="Account",
         description="Select account",
-        update=set_user,
+        update=user_update_hook,
         get=None,
         set=None,
     ) # type: ignore

--- a/bpy_speckle/properties/scene.py
+++ b/bpy_speckle/properties/scene.py
@@ -40,8 +40,10 @@ class SpeckleBranchObject(bpy.types.PropertyGroup):
         return [("0", "<none>", "<none>", 0)]
   
     def commit_update_hook(self, context: bpy.types.Context):
+        print("commit_update_hook")
         selection_state.selected_commit_id = SelectionState.get_item_id_by_index(self.commits, self.commit)
         selection_state.selected_branch_id = self.id
+        print(f"commit_update_hook: {selection_state.selected_commit_id=}, {selection_state.selected_branch_id=}")
 
     name: StringProperty(default="main") # type: ignore
     id: StringProperty(default="") # type: ignore
@@ -94,7 +96,10 @@ class SpeckleStreamObject(bpy.types.PropertyGroup):
         return [("0", "<none>", "<none>", 0)]
     
     def branch_update_hook(self, context: bpy.types.Context):
+        print("branch_update_hook")
         selection_state.selected_branch_id = SelectionState.get_item_id_by_index(self.branches, self.branch)
+        selection_state.selected_stream_id = self.id
+        print(f"branch_update_hook: {selection_state.selected_branch_id=}, {selection_state.selected_stream_id=}")
 
     name: StringProperty(default="") # type: ignore
     description: StringProperty(default="") # type: ignore
@@ -121,8 +126,11 @@ class SpeckleUserObject(bpy.types.PropertyGroup):
         stream.load_stream_branches(sstream)
 
     def stream_update_hook(self, context: bpy.types.Context):
+        print("stream_update_hook")
         stream = SelectionState.get_item_by_index(self.streams, self.active_stream)
         selection_state.selected_stream_id = stream.id
+        selection_state.selected_user_id = self.id
+        print(f"stream_update_hook: {selection_state.selected_stream_id=}, {selection_state.selected_user_id=}")
         if len(stream.branches) == 0: # do not reload on selection, same as the old behavior 
             self.fetch_stream_branches(context, stream)
 
@@ -200,7 +208,7 @@ class SpeckleSceneSettings(bpy.types.PropertyGroup):
     ) # type: ignore
 
     def get_active_user(self) -> Optional[SpeckleUserObject]:
-        if not self.active_user:
+        if self.active_user is None:
             return None
         selected_index = int(self.active_user)
         if 0 <= selected_index < len(self.users):
@@ -279,20 +287,35 @@ class SelectionState:
 selection_state = SelectionState()
 
 def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
+    print("restore_selection_state")
     # Restore branch selection state
     if selection_state.selected_branch_id != None:
+        print("restore_selection_state: branch")
         (active_user, active_stream) = speckle.validate_stream_selection()
+        print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}")
+        print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
 
         is_same_user = active_user.id == selection_state.selected_user_id
-        is_same_stream = active_stream.id == selection_state.selected_stream_id
     
-        if is_same_user and is_same_stream:
+        if is_same_user:
+            print("restore_selection_state: branch: same user")
+            active_user.active_stream = int(SelectionState.get_item_index_by_id(active_user.streams, selection_state.selected_stream_id))
+            active_stream = SelectionState.get_item_by_index(active_user.streams, active_user.active_stream)
             if branch := SelectionState.get_item_index_by_id(active_stream.branches, selection_state.selected_branch_id):
+                print("restore_selection_state: found branch")
                 active_stream.branch = branch
     
     # Restore commit selection state
     if selection_state.selected_commit_id != None:
-        (active_user, active_stream, active_branch) = speckle.validate_branch_selection()
+        print("restore_selection_state: commit")
+        (active_user, active_stream) = speckle.validate_stream_selection()
+
+        active_branch = active_stream.get_active_branch()
+
+        if active_branch is None:
+            active_branch = active_stream.branches[0]
+        print(f"restore_selection_state: {active_user.id=}, {active_stream.id=}, {active_branch.id=}")
+        print(f"restore_selection_state: {selection_state.selected_user_id=}, {selection_state.selected_stream_id=}, {selection_state.selected_branch_id=}, {selection_state.selected_commit_id=}")
 
         is_same_user = active_user.id == selection_state.selected_user_id
         is_same_stream = active_stream.id == selection_state.selected_stream_id
@@ -301,3 +324,11 @@ def restore_selection_state(speckle: SpeckleSceneSettings) -> None:
         if is_same_user and is_same_stream and is_same_branch:
             if commit := SelectionState.get_item_index_by_id(active_branch.commits, selection_state.selected_commit_id):
                 active_branch.commit = commit
+
+    print("restore_selection_state: save")
+    (active_user, active_stream, active_branch, active_commit) = speckle.validate_commit_selection()
+    # selection_state.selected_user_id = active_user.id
+    # selection_state.selected_stream_id = active_stream.id
+    selection_state.selected_branch_id = active_branch.id
+    selection_state.selected_commit_id = active_commit.id
+    print("restore_selection_state: done")


### PR DESCRIPTION
- Set selected_commit_id to new commit id on send operation
- Fix resetting active_stream on restore_selection_state
- Avoid using integer variable (active_user) as conditional