### PR TITLE
object highlight logic added

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -32,6 +32,7 @@ from .connector.ui.model_card import speckle_model_card
 from .connector.blender_operators.publish_button import SPECKLE_OT_publish
 from .connector.blender_operators.load_button import SPECKLE_OT_load
 from .connector.blender_operators.model_card_settings import SPECKLE_OT_model_card_settings, SPECKLE_OT_view_in_browser, SPECKLE_OT_view_model_versions
+from .connector.operators.select_objects import SPECKLE_OT_select_objects
 
 # States
 from .connector.states.speckle_state import register as register_speckle_state, unregister as unregister_speckle_state
@@ -51,14 +52,15 @@ def load_model_cards(scene):
 
 # Classes to load
 classes = (
-    SPECKLE_PT_main_panel, 
-    SPECKLE_OT_publish, 
-    SPECKLE_OT_load, 
+    SPECKLE_PT_main_panel,
+    SPECKLE_OT_publish,
+    SPECKLE_OT_load,
     SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list, SPECKLE_OT_add_project_by_url,
-    SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list, 
-    SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list, 
-    SPECKLE_OT_selection_filter_dialog, 
-    speckle_model_card, SPECKLE_OT_model_card_settings, SPECKLE_OT_view_in_browser, SPECKLE_OT_view_model_versions)
+    SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list,
+    SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list,
+    SPECKLE_OT_selection_filter_dialog,
+    speckle_model_card, SPECKLE_OT_model_card_settings, SPECKLE_OT_view_in_browser, SPECKLE_OT_view_model_versions,
+    SPECKLE_OT_select_objects)
 
 @bpy.app.handlers.persistent
 def load_handler(dummy):

--- a/bpy_speckle/connector/operators/select_objects.py
+++ b/bpy_speckle/connector/operators/select_objects.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.types import Operator
+from bpy.props import IntProperty
+
+class SPECKLE_OT_select_objects(Operator):
+    """Select all objects imported from this Speckle model"""
+    bl_idname = "speckle.select_objects"
+    bl_label = "Select Objects"
+    bl_options = {'REGISTER', 'UNDO'}
+    
+    model_card_index: IntProperty(
+        name="Model Card Index",
+        description="Index of the model card",
+        default=0
+    )
+    
+    def execute(self, context):
+        # Get the model card
+        model_card = context.scene.speckle_state.model_cards[self.model_card_index]
+        
+        # Construct collection name
+        collection_name = f"{model_card.model_name} - {model_card.version_id[:8]}"
+        
+        # Find the collection
+        collection = bpy.data.collections.get(collection_name)
+        if not collection:
+            self.report({'ERROR'}, f"Collection {collection_name} not found")
+            return {'CANCELLED'}
+            
+        # Deselect all objects first
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        # Select all objects in the collection and its child collections
+        def select_collection_objects(collection):
+            for obj in collection.objects:
+                obj.select_set(True)
+            for child in collection.children:
+                select_collection_objects(child)
+        
+        select_collection_objects(collection)
+        
+        # Set active object to first selected object if any objects were selected
+        selected = context.selected_objects
+        if selected:
+            context.view_layer.objects.active = selected[0]
+            
+        self.report({'INFO'}, f"Selected {len(context.selected_objects)} objects")
+        return {'FINISHED'}

--- a/bpy_speckle/connector/ui/main_panel.py
+++ b/bpy_speckle/connector/ui/main_panel.py
@@ -48,6 +48,9 @@ class SPECKLE_PT_main_panel(bpy.types.Panel):
             icon: str = 'EXPORT' if model_card.is_publish else 'IMPORT'
             row.operator("speckle.publish", text="", icon=icon)
             row.label(text=f"{model_card.model_name} - {model_card.project_name}")
+            # Add selection button
+            select_op = row.operator("speckle.select_objects", text="", icon='RESTRICT_SELECT_OFF')
+            select_op.model_card_index = model_card_index
             row.operator("speckle.model_card_settings", text="", icon='PREFERENCES').model_card_index = model_card_index
             row: UILayout = box.row()
             # Display selection summary or version ID


### PR DESCRIPTION
adds object highlight logic. For now, it's doing selection by collection name instead of storing individual ids. This was easier to implement and was basically doing the same thing. But later on, we can align it with how others are doing.

https://github.com/user-attachments/assets/a004d1c9-99f9-49a5-86de-2d9baab1e9e6

