### PR TITLE
Bilal/cnx 1601 adding models by url

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -34,7 +34,7 @@ bl_info = {
 
 # UI
 from .connector.ui.main_panel import SPECKLE_PT_main_panel
-from .connector.ui.project_selection_dialog import SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list, SPECKLE_OT_add_project_by_url
+from .connector.ui.project_selection_dialog import SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list
 from .connector.ui.model_selection_dialog import SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list
 from .connector.ui.version_selection_dialog import SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list
 from .connector.ui.selection_filter_dialog import SPECKLE_OT_selection_filter_dialog
@@ -45,6 +45,7 @@ from .connector.blender_operators.load_button import SPECKLE_OT_load
 from .connector.blender_operators.model_card_settings import SPECKLE_OT_model_card_settings, SPECKLE_OT_view_in_browser, SPECKLE_OT_view_model_versions, SPECKLE_OT_delete_model_card
 from .connector.blender_operators.select_objects import SPECKLE_OT_select_objects
 from .connector.blender_operators.add_account_button import SPECKLE_OT_add_account
+from .connector.blender_operators.add_project_by_url import SPECKLE_OT_add_project_by_url
 # States
 from .connector.states.speckle_state import register as register_speckle_state, unregister as unregister_speckle_state
 
@@ -66,13 +67,14 @@ classes = (
     SPECKLE_PT_main_panel,
     SPECKLE_OT_publish,
     SPECKLE_OT_load,
-    SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list, SPECKLE_OT_add_project_by_url,
+    SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list,
     SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list,
     SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list,
     SPECKLE_OT_selection_filter_dialog,
     speckle_model_card, SPECKLE_OT_model_card_settings, SPECKLE_OT_view_in_browser, SPECKLE_OT_view_model_versions, SPECKLE_OT_delete_model_card,
     SPECKLE_OT_select_objects,
-    SPECKLE_OT_add_account)
+    SPECKLE_OT_add_account, 
+    SPECKLE_OT_add_project_by_url)
 
 @bpy.app.handlers.persistent
 def load_handler(dummy):

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -1,0 +1,34 @@
+import bpy
+from bpy.types import Context, Event, UILayout
+
+class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
+    """
+    operator for adding a Speckle project by URL
+    """
+
+    bl_idname = "speckle.add_project_by_url"
+    bl_label = "Add Project by URL"
+    bl_description = "Add a project from a URL"
+
+    url: bpy.props.StringProperty(  # type: ignore
+        name="Project URL", description="Enter the Speckle project URL", default=""
+    )
+
+    def execute(self, context: Context) -> set[str]:
+        # TODO: Implement logic to add project using the URL
+        self.report({"INFO"}, f"Adding project from URL: {self.url}")
+        return {"FINISHED"}
+
+    def invoke(self, context: Context, event: Event) -> set[str]:
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context: Context) -> None:
+        layout: UILayout = self.layout
+        layout.prop(self, "url", text="Speckle URL")
+
+def register() -> None:
+    bpy.utils.register_class(SPECKLE_OT_add_project_by_url)
+
+def unregister() -> None:
+    bpy.utils.unregister_class(SPECKLE_OT_add_project_by_url)
+    

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -31,4 +31,22 @@ def register() -> None:
 
 def unregister() -> None:
     bpy.utils.unregister_class(SPECKLE_OT_add_project_by_url)
-    
+
+def get_model_details_by_wrapper(wrapper: StreamWrapper) -> Tuple[str, str, str, str, str, str]:
+    client = wrapper.get_client()
+    client.authenticate_with_account(wrapper.get_account())
+    account_id, project_id, project_name, model_id, model_name, version_id, load_option = "", "", "", "", "", "", ""
+    account_id = wrapper.get_account().id
+    if wrapper.stream_id:
+        project_id = wrapper.stream_id
+        project = client.project.get(project_id)
+        project_name = project.name
+    if wrapper.model_id:
+        model_id = wrapper.model_id
+        model = client.model.get(model_id, project_id)
+        model_name = model.name
+        load_option = "LATEST"
+    if wrapper.commit_id:
+        version_id = wrapper.commit_id
+        load_option = "SPECIFIC"
+    return (account_id, project_id, project_name, model_id, model_name, version_id, load_option)

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -84,7 +84,7 @@ class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
 
     def draw(self, context: Context) -> None:
         layout: UILayout = self.layout
-        layout.prop(self, "url", text="Speckle URL")
+        layout.prop(self, "url", text="")
 
 def register() -> None:
     bpy.utils.register_class(SPECKLE_OT_add_project_by_url)

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -20,6 +20,38 @@ class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
         return {"FINISHED"}
 
     def invoke(self, context: Context, event: Event) -> set[str]:
+        # Ensure all required properties exist in WindowManager
+        if not hasattr(WindowManager, "selected_account_id"):
+            WindowManager.selected_account_id = bpy.props.StringProperty()
+
+        if not hasattr(WindowManager, "selected_project_id"):
+            WindowManager.selected_project_id = bpy.props.StringProperty(
+                name="Selected Project ID"
+            )
+        if not hasattr(WindowManager, "selected_project_name"):
+            WindowManager.selected_project_name = bpy.props.StringProperty(
+                name="Selected Project Name"
+            )
+
+        if not hasattr(WindowManager, "selected_model_id"):
+            WindowManager.selected_model_id = bpy.props.StringProperty(
+                name="Selected Model ID"
+            )
+        if not hasattr(WindowManager, "selected_model_name"):
+            WindowManager.selected_model_name = bpy.props.StringProperty(
+                name="Selected Model Name"
+            )
+
+        if not hasattr(WindowManager, "selected_version_id"):
+            WindowManager.selected_version_id = bpy.props.StringProperty(
+                name="Selected Version ID"
+            )
+
+        if not hasattr(WindowManager, "selected_version_load_option"):
+            WindowManager.selected_version_load_option = bpy.props.StringProperty(
+                name="Selected Version Load Option"
+            )
+
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context: Context) -> None:

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -38,13 +38,8 @@ class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
                 wm.selected_model_name = model_name
                 if version_id:
                     wm.selected_version_id = version_id
-                    wm.selected_version_name = version_id
-        
-        if load_option == "LATEST":
-            # something funny going on here
-            wm.selected_version_id = get_latest_version(account_id, project_id, model_id)[0]
-        wm.selected_version_load_option = load_option
-            
+            wm.selected_version_id = version_id
+            wm.selected_version_load_option = load_option
         context.window.screen = context.window.screen
         context.area.tag_redraw()
         return {"FINISHED"}
@@ -107,8 +102,6 @@ def get_model_details_by_wrapper(wrapper: StreamWrapper) -> Tuple[str, str, str,
         model_id = wrapper.model_id
         model = client.model.get(model_id, project_id)
         model_name = model.name
-        load_option = "LATEST"
-    if wrapper.commit_id:
-        version_id = wrapper.commit_id
-        load_option = "SPECIFIC"
+        load_option = "LATEST" if not wrapper.commit_id else "SPECIFIC"
+        version_id = wrapper.commit_id if wrapper.commit_id else client.model.get_with_versions(model_id, project_id, versions_limit = 1).id
     return (account_id, project_id, project_name, model_id, model_name, version_id, load_option)

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -23,8 +23,11 @@ class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
         self.report({"INFO"}, f"Adding project from URL: {self.url}")
 
         wm = context.window_manager
-
-        wrapper = StreamWrapper(self.url)
+        try:
+            wrapper = StreamWrapper(self.url)
+        except Exception as e:
+            self.report({"ERROR"}, f"Failed to process URL: {str(e)}")
+            return {"CANCELLED"}
         # Get model details from the wrapper
         account_id, project_id, project_name, model_id, model_name, version_id, load_option = get_model_details_by_wrapper(wrapper)
 

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -166,6 +166,7 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         # Search field
         row = layout.row(align=True)
         row.prop(self, "search_query", icon="VIEWZOOM", text="")
+        row.operator("speckle.add_project_by_url", icon='URL', text="")
         # TODO: Add a button for adding a project by URL
         # row.operator("speckle.add_project_by_url", icon='URL', text="")
 
@@ -180,44 +181,17 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         layout.separator()
 
 
-class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
-    """
-    operator for adding a Speckle project by URL
-    """
-
-    bl_idname = "speckle.add_project_by_url"
-    bl_label = "Add Project by URL"
-    bl_description = "Add a project from a URL"
-
-    url: bpy.props.StringProperty(  # type: ignore
-        name="Project URL", description="Enter the Speckle project URL", default=""
-    )
-
-    def execute(self, context: Context) -> set[str]:
-        # TODO: Implement logic to add project using the URL
-        self.report({"INFO"}, f"Adding project from URL: {self.url}")
-        return {"FINISHED"}
-
-    def invoke(self, context: Context, event: Event) -> set[str]:
-        return context.window_manager.invoke_props_dialog(self)
-
-    def draw(self, context: Context) -> None:
-        layout: UILayout = self.layout
-        layout.prop(self, "url")
-
 
 def register() -> None:
     bpy.utils.register_class(speckle_project)
     bpy.utils.register_class(SPECKLE_UL_projects_list)
     bpy.utils.register_class(SPECKLE_OT_project_selection_dialog)
-    bpy.utils.register_class(SPECKLE_OT_add_project_by_url)
 
 
 def unregister() -> None:
     if hasattr(WindowManager, "speckle_projects"):
         del WindowManager.speckle_projects
 
-    bpy.utils.unregister_class(SPECKLE_OT_add_project_by_url)
     bpy.utils.unregister_class(SPECKLE_OT_project_selection_dialog)
     bpy.utils.unregister_class(SPECKLE_UL_projects_list)
     bpy.utils.unregister_class(speckle_project)

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -166,9 +166,7 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         # Search field
         row = layout.row(align=True)
         row.prop(self, "search_query", icon="VIEWZOOM", text="")
-        row.operator("speckle.add_project_by_url", icon='URL', text="")
-        # TODO: Add a button for adding a project by URL
-        # row.operator("speckle.add_project_by_url", icon='URL', text="")
+        row.operator("speckle.add_project_by_url", icon='LINKED', text="")
 
         layout.template_list(
             "SPECKLE_UL_projects_list",


### PR DESCRIPTION
This PR introduces functionality for adding a model via a URL.

If an invalid URL is provided, it will raise an exception.

When a project URL is supplied, it will only configure the project and redirect the user to the main panel.

If a model URL is specified, it will set both the project and model buttons, update the model to the latest version, and return the user to the main panel.

For a version URL, it will set the project, model, and version buttons, then navigate the user back to the main panel.

https://github.com/user-attachments/assets/e4ab04ea-378b-42b9-aae3-2d3df9a15bdc

