### PR TITLE
Bilal/cnx 1650 integrating workspaces to blender dui

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -35,7 +35,7 @@ bl_info = {
 
 # UI
 from .connector.ui.main_panel import SPECKLE_PT_main_panel
-from .connector.ui.project_selection_dialog import SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list
+from .connector.ui.project_selection_dialog import SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list, speckle_workspace
 from .connector.ui.model_selection_dialog import SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list
 from .connector.ui.version_selection_dialog import SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list
 from .connector.ui.selection_filter_dialog import SPECKLE_OT_selection_filter_dialog
@@ -58,6 +58,11 @@ def invoke_window_manager_properties():
         type = speckle_account
     )
     WindowManager.selected_account_id = bpy.props.StringProperty()
+    # Workspaces
+    WindowManager.speckle_workspaces = bpy.props.CollectionProperty(
+        type = speckle_workspace
+    )
+    WindowManager.selected_workspace_id = bpy.props.StringProperty()
     # Projects
     WindowManager.speckle_projects = bpy.props.CollectionProperty(
                 type=speckle_project
@@ -95,7 +100,7 @@ classes = (
     SPECKLE_PT_main_panel,
     SPECKLE_OT_publish,
     SPECKLE_OT_load,
-    SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list,
+    SPECKLE_OT_project_selection_dialog, speckle_project, SPECKLE_UL_projects_list, speckle_workspace,
     SPECKLE_OT_model_selection_dialog, speckle_model, SPECKLE_UL_models_list,
     SPECKLE_OT_version_selection_dialog, speckle_version, SPECKLE_UL_versions_list,
     SPECKLE_OT_selection_filter_dialog,

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -111,7 +111,7 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         # get projects for the selected account, using search if provided
         search = self.search_query if self.search_query.strip() else None
         projects: List[Tuple[str, str, str, str]] = get_projects_for_account(
-            self.accounts, search=search
+            self.accounts, search=search, workspace_id=self.workspaces
         )
 
         for name, role, updated, id in projects:

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -183,11 +183,12 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
             workspace: speckle_workspace = wm.speckle_workspaces.add()
             workspace.id = id
             workspace.name = name
-        wm.selected_workspace_id = self.workspaces
+        selected_workspace_id = self.workspaces
+        wm.selected_workspace_id = selected_workspace_id
 
         # Fetch projects from server
         projects: List[Tuple[str, str, str, str]] = get_projects_for_account(
-            selected_account_id
+            selected_account_id, workspace_id=selected_workspace_id
         )
 
         for name, role, updated, id in projects:

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -82,10 +82,7 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
     bl_idname = "speckle.project_selection_dialog"
     bl_label = "Select Project"
 
-    def update_workspaces_list(self, context: Context) -> None:
-        """
-        updates the list of workspaces based on the selected account
-        """
+    def update_workspaces_and_projects_list(self, context: Context) -> None:
         wm = context.window_manager
         wm.selected_account_id = self.accounts
         wm.speckle_workspaces.clear()
@@ -95,6 +92,23 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
             workspace.id = id
             workspace.name = name
         print("Updated Workspaces List!")
+
+        wm.speckle_projects.clear()
+
+        # get projects for the selected account, using search if provided
+        search = self.search_query if self.search_query.strip() else None
+        projects: List[Tuple[str, str, str, str]] = get_projects_for_account(
+            self.accounts, search=search, workspace_id=self.workspaces
+        )
+
+        for name, role, updated, id in projects:
+            project: speckle_project = wm.speckle_projects.add()
+            project.name = name
+            project.role = role
+            project.updated = updated
+            project.id = id
+        print("Updated Projects List!")
+
         return None
 
     def update_projects_list(self, context: Context) -> None:
@@ -134,7 +148,7 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         name="Account",
         description="Selected account to filter projects by",
         items=get_accounts_callback,
-        update=update_projects_list
+        update=update_workspaces_and_projects_list,
     )
 
     workspaces: bpy.props.EnumProperty(  # type: ignore

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -11,7 +11,7 @@ def get_accounts_callback(self, context):
     return [
         (
             account.id,
-            f"{account.user_name} - {account.server_url} - {account.user_email}",
+            f"{account.user_name} - {account.user_email} - {account.server_url}",
             ""
         )
         for account in wm.speckle_accounts

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -41,7 +41,7 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
     if client.active_user.can_create_personal_projects().authorized:
         workspaces_list.append(("personal", "Personal Projects (Legacy)"))
     print("Workspaces added")
-    return workspaces_list
+    return reorder_tuple(workspaces_list, get_default_workspace_id(account_id))
 
 
 def get_default_account_id() -> Optional[str]:
@@ -60,3 +60,25 @@ def get_server_url_by_account_id(account_id: str) -> Optional[str]:
         if acc.id == account_id:
             return acc.serverInfo.url
     return None
+
+def get_default_workspace_id(account_id: str) -> Optional[str]:
+    """
+    retrieves the ID of the default workspace for a given account ID
+    """
+    account = next((acc for acc in get_local_accounts() if acc.id == account_id), None)
+    client = SpeckleClient(host=account.serverInfo.url)
+    client.authenticate_with_account(account)
+    return client.active_user.get_active_workspace().id
+
+def reorder_tuple(tuple_list, target_id):
+    for i, (id, value) in enumerate(tuple_list):
+        if id == target_id:
+            # Remove the tuple from its current position
+            target_tuple = tuple_list.pop(i)
+            # Insert it at the beginning of the list
+            tuple_list.insert(0, target_tuple)
+            return tuple_list
+    
+    # If the target_id wasn't found
+    print(f"Tuple with ID {target_id} not found in the list")
+    return tuple_list

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -5,28 +5,39 @@ from specklepy.core.api.credentials import Account
 from specklepy.api.client import SpeckleClient
 from .misc import strip_non_ascii
 
+
 class speckle_account(bpy.types.PropertyGroup):
-    id:bpy.props.StringProperty() # type: ignore
-    user_name: bpy.props.StringProperty() # type: ignore
-    server_url: bpy.props.StringProperty() # type: ignore
-    user_email: bpy.props.StringProperty() # type: ignore
+    id: bpy.props.StringProperty()  # type: ignore
+    user_name: bpy.props.StringProperty()  # type: ignore
+    server_url: bpy.props.StringProperty()  # type: ignore
+    user_email: bpy.props.StringProperty()  # type: ignore
+
 
 class speckle_workspace(bpy.types.PropertyGroup):
     """
     PropertyGroup for storing workspace information
     """
+
     id: bpy.props.StringProperty(name="ID")  # type: ignore
     name: bpy.props.StringProperty()  # type: ignore
+
 
 def get_account_enum_items() -> List[Tuple[str, str, str, str]]:
     accounts: List[Account] = get_local_accounts()
     if not accounts:
-        print ("No accounts found!")
+        print("No accounts found!")
         return [("NO_ACCOUNTS", "No accounts found!", "", "")]
-    print ("Accounts added")
+    print("Accounts added")
     speckle_accounts = []
     for acc in accounts:
-        speckle_accounts.append((acc.id, strip_non_ascii(acc.userInfo.name), acc.serverInfo.url, acc.userInfo.email))
+        speckle_accounts.append(
+            (
+                acc.id,
+                strip_non_ascii(acc.userInfo.name),
+                acc.serverInfo.url,
+                acc.userInfo.email,
+            )
+        )
     return speckle_accounts
 
 
@@ -41,24 +52,34 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
 
     if workspaces_enabled:
         workspaces = client.active_user.get_workspaces().items
-        workspace_list = [(ws.id, strip_non_ascii(ws.name)) for ws in workspaces if ws.creation_state == None or ws.creation_state.completed]
-        personal_projects_text = "Personal Projects (Legacy)" 
+        workspace_list = [
+            (ws.id, strip_non_ascii(ws.name))
+            for ws in workspaces
+            if ws.creation_state == None or ws.creation_state.completed
+        ]
+        personal_projects_text = "Personal Projects (Legacy)"
     else:
         workspace_list = []
         personal_projects_text = "Personal Projects"
     # Append Personal Projects do workspace dropdown
     if client.active_user.can_create_personal_projects().authorized:
         workspace_list.append(("personal", personal_projects_text))
-    
+
     print("Workspaces added")
-    return reorder_tuple(workspace_list, get_default_workspace_id(account_id)) if workspaces_enabled else workspace_list
+    return (
+        reorder_tuple(workspace_list, get_default_workspace_id(account_id))
+        if workspaces_enabled
+        else workspace_list
+    )
 
 
 def get_default_account_id() -> Optional[str]:
     """
     retrieves the ID of the default Speckle account
     """
-    return next((acc.id for acc in get_local_accounts() if acc.isDefault), "NO_ACCOUNTS")
+    return next(
+        (acc.id for acc in get_local_accounts() if acc.isDefault), "NO_ACCOUNTS"
+    )
 
 
 def get_server_url_by_account_id(account_id: str) -> Optional[str]:
@@ -71,6 +92,7 @@ def get_server_url_by_account_id(account_id: str) -> Optional[str]:
             return acc.serverInfo.url
     return None
 
+
 def get_default_workspace_id(account_id: str) -> Optional[str]:
     """
     retrieves the ID of the default workspace for a given account ID
@@ -78,10 +100,16 @@ def get_default_workspace_id(account_id: str) -> Optional[str]:
     account = next((acc for acc in get_local_accounts() if acc.id == account_id), None)
     client = SpeckleClient(host=account.serverInfo.url)
     client.authenticate_with_account(account)
-    return client.active_user.get_active_workspace().id
+    return (
+        client.active_user.get_active_workspace().id
+        if client.active_user.get_active_workspace()
+        else "personal"
+    )
+
 
 def get_account_from_id(account_id: str) -> Optional[Account]:
     return next((acc for acc in get_local_accounts() if acc.id == account_id), None)
+
 
 def reorder_tuple(tuple_list, target_id):
     for i, (id, value) in enumerate(tuple_list):
@@ -91,7 +119,7 @@ def reorder_tuple(tuple_list, target_id):
             # Insert it at the beginning of the list
             tuple_list.insert(0, target_tuple)
             return tuple_list
-    
+
     # If the target_id wasn't found
     print(f"Tuple with ID {target_id} not found in the list")
     return tuple_list

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -41,7 +41,7 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
     if client.active_user.can_create_personal_projects:
         workspaces_list.append(("personal", "Personal Projects (Legacy)"))
     print("Workspaces added")
-    return [(ws.id, ws.name) for ws in workspaces]
+    return workspaces_list
 
 
 def get_default_account_id() -> Optional[str]:

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -38,7 +38,9 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
     client = SpeckleClient(host=account.serverInfo.url)
     client.authenticate_with_account(account)
     workspaces = client.active_user.get_workspaces().items
-    workspaces_list = [(ws.id, strip_non_ascii(ws.name)) for ws in workspaces]
+    workspaces_list = [
+        (ws.id, strip_non_ascii(ws.name)) for ws in workspaces if ws.creation_state == None or ws.creation_state.completed
+    ]
     if client.active_user.can_create_personal_projects().authorized:
         workspaces_list.append(("personal", "Personal Projects (Legacy)"))
     

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -38,7 +38,7 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
     client.authenticate_with_account(account)
     workspaces = client.active_user.get_workspaces().items
     workspaces_list = [(ws.id, ws.name) for ws in workspaces]
-    if client.active_user.can_create_personal_projects:
+    if client.active_user.can_create_personal_projects().authorized:
         workspaces_list.append(("personal", "Personal Projects (Legacy)"))
     print("Workspaces added")
     return workspaces_list

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -3,6 +3,7 @@ from specklepy.api.credentials import get_local_accounts
 from typing import List, Tuple, Optional
 from specklepy.core.api.credentials import Account
 from specklepy.api.client import SpeckleClient
+from .misc import strip_non_ascii
 
 class speckle_account(bpy.types.PropertyGroup):
     id:bpy.props.StringProperty() # type: ignore
@@ -25,7 +26,7 @@ def get_account_enum_items() -> List[Tuple[str, str, str, str]]:
     print ("Accounts added")
     speckle_accounts = []
     for acc in accounts:
-        speckle_accounts.append((acc.id, acc.userInfo.name, acc.serverInfo.url, acc.userInfo.email))
+        speckle_accounts.append((acc.id, strip_non_ascii(acc.userInfo.name), acc.serverInfo.url, acc.userInfo.email))
     return speckle_accounts
 
 
@@ -37,9 +38,10 @@ def get_workspaces(account_id: str) -> List[Tuple[str, str]]:
     client = SpeckleClient(host=account.serverInfo.url)
     client.authenticate_with_account(account)
     workspaces = client.active_user.get_workspaces().items
-    workspaces_list = [(ws.id, ws.name) for ws in workspaces]
+    workspaces_list = [(ws.id, strip_non_ascii(ws.name)) for ws in workspaces]
     if client.active_user.can_create_personal_projects().authorized:
         workspaces_list.append(("personal", "Personal Projects (Legacy)"))
+    
     print("Workspaces added")
     return reorder_tuple(workspaces_list, get_default_workspace_id(account_id))
 

--- a/bpy_speckle/connector/utils/misc.py
+++ b/bpy_speckle/connector/utils/misc.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-
+import re
 
 def format_relative_time(timestamp) -> str:
     """
@@ -45,3 +45,7 @@ def format_role(role: str) -> str:
     """
     split_role = role.split(":")
     return f"{split_role[1]}"
+
+def strip_non_ascii(text):
+    # Keep English letters, digits, spaces and basic punctuation
+    return re.sub(r'[^a-zA-Z0-9\s.,!?]', '', text)

--- a/bpy_speckle/connector/utils/model_manager.py
+++ b/bpy_speckle/connector/utils/model_manager.py
@@ -3,7 +3,7 @@ from specklepy.api.credentials import get_local_accounts, Account
 from specklepy.core.api.inputs.project_inputs import ProjectModelsFilter
 from specklepy.core.api.models.current import Model
 from typing import List, Tuple, Optional
-from .misc import format_relative_time
+from .misc import format_relative_time, strip_non_ascii
 
 
 def get_models_for_project(
@@ -43,7 +43,7 @@ def get_models_for_project(
         ).items
 
         return [
-            (model.name, model.id, format_relative_time(model.updated_at))
+            (strip_non_ascii(model.name), model.id, format_relative_time(model.updated_at))
             for model in models
         ]
 

--- a/bpy_speckle/connector/utils/project_manager.py
+++ b/bpy_speckle/connector/utils/project_manager.py
@@ -24,7 +24,9 @@ def get_projects_for_account(
         client = SpeckleClient(host=account.serverInfo.url)
         client.authenticate_with_account(account)
 
-        filter = UserProjectsFilter(search=search, workspaceId=workspace_id) if search else UserProjectsFilter(workspaceId=workspace_id)
+        personal_only = workspace_id == "personal"
+        workspace_id = None if personal_only else workspace_id
+        filter = UserProjectsFilter(search=search, workspaceId=workspace_id, personalOnly=personal_only)
 
         projects = client.active_user.get_projects(limit=10, filter=filter).items
 

--- a/bpy_speckle/connector/utils/project_manager.py
+++ b/bpy_speckle/connector/utils/project_manager.py
@@ -3,8 +3,7 @@ from specklepy.api.credentials import get_local_accounts
 from specklepy.core.api.inputs.user_inputs import UserProjectsFilter
 from typing import List, Tuple, Optional
 from specklepy.core.api.credentials import Account
-from .misc import format_relative_time, format_role
-
+from .misc import format_relative_time, format_role, strip_non_ascii
 
 def get_projects_for_account(
     account_id: str, workspace_id: str = None, search: Optional[str] = None
@@ -32,7 +31,7 @@ def get_projects_for_account(
 
         return [
             (
-                project.name,
+                strip_non_ascii(project.name),
                 format_role(project.role),
                 format_relative_time(project.updated_at),
                 project.id,

--- a/bpy_speckle/connector/utils/project_manager.py
+++ b/bpy_speckle/connector/utils/project_manager.py
@@ -7,7 +7,7 @@ from .misc import format_relative_time, format_role
 
 
 def get_projects_for_account(
-    account_id: str, search: Optional[str] = None
+    account_id: str, workspace_id: str = None, search: Optional[str] = None
 ) -> List[Tuple[str, str, str, str]]:
     """
     fetches projects for a given account from the Speckle server
@@ -24,7 +24,7 @@ def get_projects_for_account(
         client = SpeckleClient(host=account.serverInfo.url)
         client.authenticate_with_account(account)
 
-        filter = UserProjectsFilter(search=search) if search else None
+        filter = UserProjectsFilter(search=search, workspaceId=workspace_id) if search else UserProjectsFilter(workspaceId=workspace_id)
 
         projects = client.active_user.get_projects(limit=10, filter=filter).items
 

--- a/bpy_speckle/connector/utils/version_manager.py
+++ b/bpy_speckle/connector/utils/version_manager.py
@@ -1,7 +1,7 @@
 from specklepy.api.client import SpeckleClient
 from specklepy.api.credentials import get_local_accounts, Account
 from typing import List, Tuple, Optional
-from .misc import format_relative_time
+from .misc import format_relative_time, strip_non_ascii
 from specklepy.core.api.inputs.model_inputs import ModelVersionsFilter
 from specklepy.core.api.models.current import Version
 
@@ -38,15 +38,15 @@ def get_versions_for_model(
         # Get versions
         versions: List[Version] = client.version.get_versions(
             project_id=project_id, model_id=model_id, limit=10, filter=filter
-        ).items
+        )
 
         return [
             (
                 version.id,
-                version.message or "No message",
+                strip_non_ascii(version.message) or "No message",
                 format_relative_time(version.created_at),
             )
-            for version in versions
+            for version in versions if not version.referenced_object
         ]
 
     except Exception as e:
@@ -90,7 +90,7 @@ def get_latest_version(
         latest = versions[0]
         return (
             latest.id,
-            latest.message or "No message",
+            strip_non_ascii(latest.message) or "No message",
             format_relative_time(latest.created_at),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ version = "3.0.0"
 description = "Next-Gen Speckle connector for Blender!"
 requires-python = ">=3.11.9, <4.0.0"
 license = "Apache-2.0"
-dependencies = [
-    "specklepy>=3.0.0a9"
-]
+dependencies = ["specklepy>=3.0.0a11"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Next-Gen Speckle connector for Blender!"
 requires-python = ">=3.11.9, <4.0.0"
 license = "Apache-2.0"
 dependencies = [
-    "specklepy>=3.0.0a4"
+    "specklepy>=3.0.0a8"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Next-Gen Speckle connector for Blender!"
 requires-python = ">=3.11.9, <4.0.0"
 license = "Apache-2.0"
 dependencies = [
-    "specklepy>=3.0.0a8"
+    "specklepy>=3.0.0a9"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
This PR adds Workspaces to Blender addon. Now, there is a new dropdown in project selection dialog:
- It populates workspaces associated with the selected account.
- When user switches accounts, workspaces list is repopulated.
- For non-workspace projects, Personal Projects option is available.
- Only valid versions are listed.

This PR also includes fixes for:
- Account dropdown running in the background continuously: We now only fetch account during invoke or when user switches accounts.
- Text in dropdowns with special characters: We now strip any non-ascii chars from the string. This was the easiest to implement.
- We bumped specklepy version used to use workspace related methods.
- 

TODO: Test with a server without workspaces.


https://github.com/user-attachments/assets/4786bcc7-484f-4ddf-8fc2-10838d4cf142

