### PR TITLE
fix: unit conversion for instances

### DIFF
--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -1297,7 +1297,6 @@ def instance_definition_proxy_to_native(
 def proxy_scale(speckle_object: Base, fallback: float = 1.0) -> float:
     """
     determines the correct scale factor based on object units and Blender settings
-    (will change it in the future)
     """
     unit_settings = bpy.context.scene.unit_settings
 
@@ -1310,13 +1309,15 @@ def proxy_scale(speckle_object: Base, fallback: float = 1.0) -> float:
 
     unit_scale = 1.0
 
-    if hasattr(speckle_object, "units"):
-        if speckle_object.units == "cm":
-            unit_scale = 0.01
-        elif speckle_object.units == "mm":
-            unit_scale = 0.001
-        elif speckle_object.units == "m":
-            unit_scale = 1.0
+    if hasattr(speckle_object, "units") and speckle_object.units:
+        try:
+            # get scale factor to convert from object units to meters
+            unit_scale = get_scale_factor_to_meters(
+                get_units_from_string(speckle_object.units)
+            )
+        except Exception as e:
+            print(f"[WARNING] Failed to determine unit scale: {str(e)}")
+            unit_scale = fallback
 
     final_scale = unit_scale / blender_scale
 


### PR DESCRIPTION
## Problem
When converting models with instances in non-metric units the transformations were incorrect because the unit conversion was hard-coded. Related to the issue:

https://linear.app/speckle/issue/CNX-1774/loading-sketchup-models-in-blender

## Changes
- Removed hardcoded unit conversions in `proxy_scale`
- Integrated with Speckle's unit system for consistent unit handling
- Added proper error handling for unit conversion failures
