### PR TITLE
Set Viewport Display color of materials

### DIFF
--- a/bpy_speckle/converter/utils.py
+++ b/bpy_speckle/converter/utils.py
@@ -58,14 +58,14 @@ def create_material_from_proxy(
             diffuse_rgba[2],
             1.0,
         )
-        # set viewport display color
-        material.diffuse_color = (diffuse_rgba[0], diffuse_rgba[1], diffuse_rgba[2], 1.0)
+
 
     if hasattr(render_material, "opacity"):
         opacity = float(render_material.opacity)
         if opacity < 1.0:
             material.blend_method = "BLEND"
             bsdf.inputs["Alpha"].default_value = opacity
+    
 
     if hasattr(render_material, "metalness"):
         metalness = float(render_material.metalness)
@@ -88,6 +88,9 @@ def create_material_from_proxy(
                 1.0,
             )
             bsdf.inputs["Emission Strength"].default_value = 1.0
+    
+    # set viewport display color
+    material.diffuse_color = (diffuse_rgba[0], diffuse_rgba[1], diffuse_rgba[2], opacity)
 
     return material
 

--- a/bpy_speckle/converter/utils.py
+++ b/bpy_speckle/converter/utils.py
@@ -58,6 +58,8 @@ def create_material_from_proxy(
             diffuse_rgba[2],
             1.0,
         )
+        # set viewport display color
+        material.diffuse_color = (diffuse_rgba[0], diffuse_rgba[1], diffuse_rgba[2], 1.0)
 
     if hasattr(render_material, "opacity"):
         opacity = float(render_material.opacity)

--- a/bpy_speckle/converter/utils.py
+++ b/bpy_speckle/converter/utils.py
@@ -90,7 +90,8 @@ def create_material_from_proxy(
             bsdf.inputs["Emission Strength"].default_value = 1.0
     
     # set viewport display color
-    material.diffuse_color = (diffuse_rgba[0], diffuse_rgba[1], diffuse_rgba[2], opacity)
+    if hasattr(render_material, "diffuse") and hasattr(render_material, "opacity"):
+        material.diffuse_color = (diffuse_rgba[0], diffuse_rgba[1], diffuse_rgba[2], opacity)
 
     return material
 


### PR DESCRIPTION
[DO NOT MERGE UNTIL TESTED WITH SPECKLEPY FIXES]

This PR sets the viewport display value of the materials in Blender. It sets the diffuse colors and opacity from render materials.

This ends up in a much nicer looking default viewport. Its a nice UX improvement.

https://github.com/user-attachments/assets/9b3f85c4-785c-4b99-b0ab-0f4e8fb5e74c


