### PR TITLE
fix: global import of bl_info

### DIFF
--- a/bpy_speckle/connector/blender_operators/publish_button.py
+++ b/bpy_speckle/connector/blender_operators/publish_button.py
@@ -18,7 +18,7 @@ from ...converter.to_speckle.material_to_speckle import (
 )
 from ...converter.utils import get_project_workspace_id
 from specklepy.logging import metrics
-from ....bpy_speckle import bl_info
+from ... import bl_info
 
 
 class SPECKLE_OT_publish(bpy.types.Operator):

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -19,7 +19,7 @@ from ...converter.to_native import (
     find_instance_definitions,
 )
 from specklepy.logging import metrics
-from ....bpy_speckle import bl_info
+from ... import bl_info
 
 
 def load_operation(context: Context) -> None:


### PR DESCRIPTION
the import path of bl_info is throwing an error if the python is not added in users global path. this relative import will fix that. 