### PR TITLE
set version message

### DIFF
--- a/bpy_speckle/connector/blender_operators/publish_button.py
+++ b/bpy_speckle/connector/blender_operators/publish_button.py
@@ -12,8 +12,14 @@ class SPECKLE_OT_publish(bpy.types.Operator):
     bl_label = "Publish to Speckle"
     bl_description = "Publish selected objects to Speckle"
 
+    version_message: bpy.props.StringProperty(name="Version Message")  # type: ignore
+
+    def draw(self, context: Context) -> None:
+        layout = self.layout
+        layout.prop(self, "version_message")
+
     def invoke(self, context: Context, event: Event) -> Set[str]:
-        return self.execute(context)
+        return context.window_manager.invoke_props_dialog(self)
 
     def execute(self, context: Context) -> Set[str]:
         wm = context.window_manager
@@ -56,7 +62,9 @@ class SPECKLE_OT_publish(bpy.types.Operator):
             self.report({"ERROR"}, "None of the selected objects could be found")
             return {"CANCELLED"}
 
-        success, message, version_id = publish_operation(context, objects_to_convert)
+        success, message, version_id = publish_operation(
+            context, objects_to_convert, self.version_message
+        )
 
         if not success:
             self.report({"ERROR"}, message)
@@ -90,4 +98,5 @@ class SPECKLE_OT_publish(bpy.types.Operator):
         wm.selected_version_id = ""
 
         self.report({"INFO"}, message)
+        context.area.tag_redraw()
         return {"FINISHED"}

--- a/bpy_speckle/connector/operations/publish_operation.py
+++ b/bpy_speckle/connector/operations/publish_operation.py
@@ -21,7 +21,7 @@ from ... import bl_info
 
 
 def publish_operation(
-    context: Context, objects_to_convert: List
+    context: Context, objects_to_convert: List, version_message: str
 ) -> Tuple[bool, str, Optional[str]]:
     """
     publish objects to speckle
@@ -58,7 +58,7 @@ def publish_operation(
             objectId=obj_id,
             modelId=wm.selected_model_id,
             projectId=wm.selected_project_id,
-            message="",
+            message=version_message,
             sourceApplication="blender",
         )
 

--- a/bpy_speckle/connector/operations/publish_operation.py
+++ b/bpy_speckle/connector/operations/publish_operation.py
@@ -21,7 +21,9 @@ from ... import bl_info
 
 
 def publish_operation(
-    context: Context, objects_to_convert: List, version_message: str
+    context: Context,
+    objects_to_convert: List,
+    version_message: str = "",
 ) -> Tuple[bool, str, Optional[str]]:
     """
     publish objects to speckle


### PR DESCRIPTION
This PR introduces the ability to set a version message before sending it out. We’ve got a similar feature in DUI3 where users can set a version message afterwards, but doing it beforehand is way simpler in terms of Blender UI work.


https://github.com/user-attachments/assets/bc7e8284-6401-40ab-bb39-0eb968efe550

