### PR TITLE
Bilal/select objects by name

### DIFF
--- a/bpy_speckle/connector/blender_operators/load_button.py
+++ b/bpy_speckle/connector/blender_operators/load_button.py
@@ -25,7 +25,9 @@ class SPECKLE_OT_load(bpy.types.Operator):
         model_card.is_publish = False
         model_card.load_option = wm.selected_version_load_option
         model_card.version_id = wm.selected_version_id
-        model_card.collection_name = f"{wm.selected_model_name} - {wm.selected_version_id[:8]}"
+        model_card.collection_name = (
+            f"{wm.selected_model_name} - {wm.selected_version_id[:8]}"
+        )
 
         # Load selected model version
         load_operation(context)

--- a/bpy_speckle/connector/blender_operators/publish_button.py
+++ b/bpy_speckle/connector/blender_operators/publish_button.py
@@ -87,6 +87,9 @@ class SPECKLE_OT_publish(bpy.types.Operator):
             model_card.collection_name = (
                 f"{getattr(wm, 'selected_model_name', 'Model')} - {version_id[:8]}"
             )
+            for obj in objects_to_convert:
+                s_obj = model_card.objects.add()
+                s_obj.name = obj.name
 
         # clear selected model details from Window Manager
         wm.selected_account_id = ""

--- a/bpy_speckle/connector/blender_operators/select_objects.py
+++ b/bpy_speckle/connector/blender_operators/select_objects.py
@@ -32,7 +32,8 @@ class SPECKLE_OT_select_objects(Operator):
             blender_obj = bpy.data.objects.get(obj.name)
             if not blender_obj:
                 continue
-            blender_obj.select_set(True)
+            if blender_obj.name in context.view_layer.objects:
+                blender_obj.select_set(True)
 
         selected = context.selected_objects
         if selected:

--- a/bpy_speckle/connector/blender_operators/select_objects.py
+++ b/bpy_speckle/connector/blender_operators/select_objects.py
@@ -29,11 +29,10 @@ class SPECKLE_OT_select_objects(Operator):
 
         # select objects in model card
         for obj in model_card.objects:
-            obj = bpy.data.objects.get(obj.name)
-            try:
-                obj.select_set(True)
-            except Exception:
+            blender_obj = bpy.data.objects.get(obj.name)
+            if not blender_obj:
                 continue
+            blender_obj.select_set(True)
 
         selected = context.selected_objects
         if selected:

--- a/bpy_speckle/connector/blender_operators/select_objects.py
+++ b/bpy_speckle/connector/blender_operators/select_objects.py
@@ -24,24 +24,16 @@ class SPECKLE_OT_select_objects(Operator):
             self.report({"ERROR"}, "Model card not found")
             return {"CANCELLED"}
 
-        collection_name = model_card.collection_name
-
-        collection = bpy.data.collections.get(collection_name)
-        if not collection:
-            self.report({"ERROR"}, f"Collection {collection_name} not found")
-            return {"CANCELLED"}
-
         # deselect all objects first
         bpy.ops.object.select_all(action="DESELECT")
 
-        # select all objects in the collection and its child collections
-        def select_collection_objects(collection):
-            for obj in collection.objects:
+        # select objects in model card
+        for obj in model_card.objects:
+            obj = bpy.data.objects.get(obj.name)
+            try:
                 obj.select_set(True)
-            for child in collection.children:
-                select_collection_objects(child)
-
-        select_collection_objects(collection)
+            except Exception:
+                continue
 
         selected = context.selected_objects
         if selected:

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -290,7 +290,10 @@ def load_operation(context: Context) -> None:
     # get model card and add objects to it
     model_card = context.scene.speckle_state.model_cards[-1]
     for obj in converted_objects.values():
-        s_obj = model_card.objects.add()
-        s_obj.name = obj.name
+        if isinstance(obj, bpy.types.Object):
+            if obj.name in (o.name for o in model_card.objects):
+                continue
+            s_obj = model_card.objects.add()
+            s_obj.name = obj.name
 
     print(f"\nLoad process completed. Imported {len(converted_objects)} objects.")

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -287,4 +287,10 @@ def load_operation(context: Context) -> None:
         if area.type == "OUTLINER":
             area.tag_redraw()
 
+    # get model card and add objects to it
+    model_card = context.scene.speckle_state.model_cards[-1]
+    for obj in converted_objects.values():
+        s_obj = model_card.objects.add()
+        s_obj.name = obj.name
+
     print(f"\nLoad process completed. Imported {len(converted_objects)} objects.")

--- a/bpy_speckle/connector/ui/model_card.py
+++ b/bpy_speckle/connector/ui/model_card.py
@@ -1,5 +1,6 @@
 import bpy
 from typing import Dict, Any
+from .selection_filter_dialog import speckle_object
 
 
 class speckle_model_card(bpy.types.PropertyGroup):
@@ -44,6 +45,7 @@ class speckle_model_card(bpy.types.PropertyGroup):
     collection_name: bpy.props.StringProperty(
         name="Collection Name", description="Name of the collection", default=""
     )  # type: ignore
+    objects: bpy.props.CollectionProperty(type=speckle_object)  # type: ignore
 
     def get_model_card_id(self) -> str:
         if not self.project_id or not self.model_id:
@@ -67,6 +69,7 @@ class speckle_model_card(bpy.types.PropertyGroup):
             "selection_summary": self.selection_summary,
             "version_id": self.version_id,
             "collection_name": self.collection_name,
+            "objects": self.objects,
         }
 
     @classmethod
@@ -85,3 +88,4 @@ class speckle_model_card(bpy.types.PropertyGroup):
         item.selection_summary = data["selection_summary"]
         item.version_id = data["version_id"]
         item.collection_name = data["collection_name"]
+        item.objects = data["objects"]

--- a/bpy_speckle/connector/ui/model_card.py
+++ b/bpy_speckle/connector/ui/model_card.py
@@ -69,7 +69,7 @@ class speckle_model_card(bpy.types.PropertyGroup):
             "selection_summary": self.selection_summary,
             "version_id": self.version_id,
             "collection_name": self.collection_name,
-            "objects": self.objects,
+            "objects": [obj.name for obj in self.objects],
         }
 
     @classmethod
@@ -88,4 +88,7 @@ class speckle_model_card(bpy.types.PropertyGroup):
         item.selection_summary = data["selection_summary"]
         item.version_id = data["version_id"]
         item.collection_name = data["collection_name"]
-        item.objects = data["objects"]
+        item.objects.clear()
+        for obj_name in data.get("objects", []):
+            s_obj = item.objects.add()
+            s_obj.name = obj_name


### PR DESCRIPTION
## Problem
The object highlight button in the model card only worked for elements within their original collections. The highlighting logic was collection-based, so moving an element out of its collection would break the highlighting functionality for that object.
## Solution
Replace collection-based highlighting with object name-based highlighting by storing object names directly in the model card.
## Changes

- Store object names in model card instead of relying on collection hierarchy
- Update highlighting logic to use stored object names for element selection
- Support highlighting for both publish and load model cards
- Maintain highlighting functionality when objects are moved between collections

## Testing

- [x] Highlighting works in publish model cards
- [x]  Highlighting works in load model cards
- [x]  Highlighting persists after moving objects out of collections
- [x] Works when opening saved model cards

https://github.com/user-attachments/assets/95defb0b-79f5-4cdf-81bd-08df79559224


