### PR TITLE
Bilal/cnx 2012 account selection button

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -84,6 +84,12 @@ from .connector.states.speckle_state import (
     unregister as unregister_speckle_state,
 )
 
+# Utils
+from .connector.ui.account_selection_dialog import (
+    SPECKLE_OT_account_selection_dialog,
+    SPECKLE_UL_accounts_list,
+)
+
 
 def invoke_window_manager_properties():
     # Accounts
@@ -164,6 +170,8 @@ classes = (
     SPECKLE_OT_create_project,
     SPECKLE_OT_create_model,
     speckle_account,
+    SPECKLE_OT_account_selection_dialog,
+    SPECKLE_UL_accounts_list,
 )
 
 

--- a/bpy_speckle/connector/blender_operators/add_project_by_url.py
+++ b/bpy_speckle/connector/blender_operators/add_project_by_url.py
@@ -68,38 +68,6 @@ class SPECKLE_OT_add_project_by_url(bpy.types.Operator):
         return {"FINISHED"}
 
     def invoke(self, context: Context, event: Event) -> set[str]:
-        # Ensure all required properties exist in WindowManager
-        if not hasattr(WindowManager, "selected_account_id"):
-            WindowManager.selected_account_id = bpy.props.StringProperty()
-
-        if not hasattr(WindowManager, "selected_project_id"):
-            WindowManager.selected_project_id = bpy.props.StringProperty(
-                name="Selected Project ID"
-            )
-        if not hasattr(WindowManager, "selected_project_name"):
-            WindowManager.selected_project_name = bpy.props.StringProperty(
-                name="Selected Project Name"
-            )
-
-        if not hasattr(WindowManager, "selected_model_id"):
-            WindowManager.selected_model_id = bpy.props.StringProperty(
-                name="Selected Model ID"
-            )
-        if not hasattr(WindowManager, "selected_model_name"):
-            WindowManager.selected_model_name = bpy.props.StringProperty(
-                name="Selected Model Name"
-            )
-
-        if not hasattr(WindowManager, "selected_version_id"):
-            WindowManager.selected_version_id = bpy.props.StringProperty(
-                name="Selected Version ID"
-            )
-
-        if not hasattr(WindowManager, "selected_version_load_option"):
-            WindowManager.selected_version_load_option = bpy.props.StringProperty(
-                name="Selected Version Load Option"
-            )
-
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context: Context) -> None:

--- a/bpy_speckle/connector/ui/account_selection_dialog.py
+++ b/bpy_speckle/connector/ui/account_selection_dialog.py
@@ -87,7 +87,7 @@ class SPECKLE_OT_account_selection_dialog(bpy.types.Operator):
         wm = context.window_manager
         # update the selected account id
         wm.selected_account_id = wm.speckle_accounts[self.account_index].id
-        print(f"Selected account: {wm.selected_account_id}")
+        self.report({"INFO"}, f"Selected account: {wm.selected_account_id}")
         update_workspaces_list(context)
         update_projects_list(context)
         # redraw the area

--- a/bpy_speckle/connector/ui/account_selection_dialog.py
+++ b/bpy_speckle/connector/ui/account_selection_dialog.py
@@ -1,0 +1,83 @@
+import bpy
+from bpy.types import Context, Event
+from ..utils.account_manager import (
+    get_account_enum_items,
+    speckle_account,
+)
+
+
+class SPECKLE_UL_accounts_list(bpy.types.UIList):
+    """
+    UIList for displaying accounts
+    """
+
+    def draw_item(
+        self,
+        context: Context,
+        layout: bpy.types.UILayout,
+        data: bpy.types.PropertyGroup,
+        item: bpy.types.PropertyGroup,
+        icon: str,
+        active_data: bpy.types.PropertyGroup,
+        active_propname: str,
+    ) -> None:
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            row = layout.row()
+            row.label(text=item.user_name)
+            row.label(text=item.server_url)
+            row.label(text=item.user_email)
+        elif self.layout_type == "GRID":
+            layout.alignment = "CENTER"
+            layout.label(text=item.user_name)
+
+
+class SPECKLE_OT_account_selection_dialog(bpy.types.Operator):
+    """
+    operator for displaying and handling the account selection dialog
+    """
+
+    bl_idname = "speckle.account_selection_dialog"
+    bl_label = "Select Account"
+    bl_description = "Select account"
+
+    account_index: bpy.props.IntProperty(default=0)  # type: ignore
+
+    def invoke(self, context: Context, event: Event) -> set[str]:
+        wm = context.window_manager
+        # Clear existing accounts
+        wm.speckle_accounts.clear()
+
+        # Save selected account
+        current_account_index = 0
+
+        # Fetch accounts
+        for i, (id, user_name, server_url, user_email) in enumerate(
+            get_account_enum_items()
+        ):
+            account: speckle_account = wm.speckle_accounts.add()
+            account.id = id
+            account.user_name = user_name
+            account.server_url = server_url
+            account.user_email = user_email
+            if id == wm.selected_account_id:
+                current_account_index = i
+
+        self.account_index = current_account_index
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context: Context) -> None:
+        layout = self.layout
+        layout.label(text="Select account")
+        layout.template_list(
+            "SPECKLE_UL_accounts_list",
+            "",
+            context.window_manager,
+            "speckle_accounts",
+            self,
+            "account_index",
+        )
+
+    def execute(self, context: Context) -> set[str]:
+        wm = context.window_manager
+        wm.selected_account_id = wm.speckle_accounts[self.account_index].id
+        return {"FINISHED"}

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -187,21 +187,17 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         row = layout.row()
 
         if wm.selected_account_id == "NO_ACCOUNTS":
-            account_button_text = "Add Account"
-            account_button_icon = "WORLD"
-        else:
-            account = get_account_from_id(wm.selected_account_id)
-            account_button_text = f"{account.userInfo.name} - {account.userInfo.email} - {account.serverInfo.url}"
-            account_button_icon = "USER"
-
-        row.operator(
-            "speckle.account_selection_dialog",
-            icon=account_button_icon,
-            text=account_button_text,
-        )
+            row.operator("speckle.add_account", icon="WORLD", text="Sign In")
 
         # if no accounts then don't show workspaces or projects list
         if wm.selected_account_id != "NO_ACCOUNTS":
+            account = get_account_from_id(wm.selected_account_id)
+
+            row.operator(
+                "speckle.account_selection_dialog",
+                icon="USER",
+                text=f"{account.userInfo.name} - {account.userInfo.email} - {account.serverInfo.url}",
+            )
             # Workspace selection
             row = layout.row()
             if wm.selected_workspace_id != "NO_WORKSPACES":

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -244,7 +244,11 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         # Account selection
         row = layout.row()
         if wm.selected_account_id != "NO_ACCOUNTS":
-            row.prop(self, "accounts", text="")
+            row.operator(
+                "speckle.account_selection_dialog",
+                icon="WORLD",
+                text="Select Account",
+            )
         add_account_button_text = (
             "Sign In" if wm.selected_account_id == "NO_ACCOUNTS" else ""
         )


### PR DESCRIPTION
This PR replaces dropdown menu with a button. This is to align it with the upcoming change for replacing workspace dropdown to a button for performance reasons.

This PR changes accounts adding and signing in flows.

- If users have no account, account button will be a sign in button.

    https://github.com/user-attachments/assets/c8b9def0-0fa7-4d46-bfdb-723c49de4a57


- If there is an account, clicking on it will open account selection dialog.
    - User can add new accounts from this dialog.

        https://github.com/user-attachments/assets/3f505a0e-d07a-439a-9938-2a3554153a22


    - User can switch between different accounts.

        https://github.com/user-attachments/assets/43b80c41-fb30-4cdd-81dd-d9b67ee0dbf3


Having a separate dialog for accounts will enable us to add remove account functionality much easier.

