### PR TITLE
Bilal/handle no account state

### DIFF
--- a/bpy_speckle/connector/ui/main_panel.py
+++ b/bpy_speckle/connector/ui/main_panel.py
@@ -169,5 +169,5 @@ class SPECKLE_PT_main_panel(bpy.types.Panel):
 
                 # Settings button in the model card
                 row_1.operator(
-                    "speckle.model_card_settings", text="", icon="THREE_DOTS"
+                    "speckle.model_card_settings", text="", icon="COLLAPSEMENU"
                 ).model_card_id = model_card.get_model_card_id()

--- a/bpy_speckle/connector/utils/account_manager.py
+++ b/bpy_speckle/connector/utils/account_manager.py
@@ -104,6 +104,9 @@ def get_active_workspace(account_id: str) -> Optional[Dict[str, str]]:
     retrieves the ID of the default workspace for a given account ID
     """
     account = next((acc for acc in get_local_accounts() if acc.id == account_id), None)
+    if account is None:
+        print(f"No account found for ID: {account_id}, returning default workspace.")
+        return {"id": "personal", "name": "Personal Projects"}
     client = SpeckleClient(host=account.serverInfo.url)
     client.authenticate_with_account(account)
     active_workspace = client.active_user.get_active_workspace()


### PR DESCRIPTION
This PR includes:
- Fix for when no accounts are found. It would throw an exception. Now, we handle exception and show sign in button as expected.
- Replaces three dots with an hamburger for "model card menu". This is aligned with DUI3 icons.
![image](https://github.com/user-attachments/assets/f4290c87-8ff7-4c6d-a87f-18502a96a5b5)
