### PR TITLE
Ensure hashes are included in requirements.txt creaiton

### DIFF
--- a/export_dependencies.sh
+++ b/export_dependencies.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-uv pip compile pyproject.toml --output-file bpy_speckle/requirements.txt --all-extras
+uv pip compile pyproject.toml --output-file bpy_speckle/requirements.txt --generate-hashes


### PR DESCRIPTION
The v2 connector would output hashes in the requirements.txt
This is an important security guarantee that helps ensure that the user pulls what the dependencies that we intend them to pull.
 