### PR TITLE
Persistent modifiers, visibility settings and tracking by applicationId

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -34,10 +34,10 @@ bl_info = {
 
 # UI
 from .connector.ui.main_panel import SPECKLE_PT_main_panel
+from .connector.utils.account_manager import speckle_workspace
 from .connector.ui.project_selection_dialog import (
     SPECKLE_OT_project_selection_dialog,
     SPECKLE_UL_projects_list,
-    speckle_workspace,
 )
 from .connector.ui.model_selection_dialog import (
     SPECKLE_OT_model_selection_dialog,

--- a/bpy_speckle/connector/blender_operators/model_card_load_button.py
+++ b/bpy_speckle/connector/blender_operators/model_card_load_button.py
@@ -29,12 +29,8 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
             self.report({"ERROR"}, "Model card not found")
             return {"CANCELLED"}
 
-        # store visibility settings before deleting objects
         store_visibility_settings(model_card)
-
-        # store modifier settings before deleting objects
         store_modifier_settings(model_card)
-
         delete_model_card_objects(model_card, context)
 
         # set wm

--- a/bpy_speckle/connector/blender_operators/model_card_load_button.py
+++ b/bpy_speckle/connector/blender_operators/model_card_load_button.py
@@ -6,6 +6,7 @@ from ..operations.load_operation import load_operation
 from ..utils.model_card_utils import (
     delete_model_card_objects,
     update_model_card_objects,
+    store_visibility_settings,
 )
 
 
@@ -26,6 +27,9 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
         if model_card is None:
             self.report({"ERROR"}, "Model card not found")
             return {"CANCELLED"}
+
+        # store visibility settings before deleting objects
+        store_visibility_settings(model_card)
 
         delete_model_card_objects(model_card, context)
 

--- a/bpy_speckle/connector/blender_operators/model_card_load_button.py
+++ b/bpy_speckle/connector/blender_operators/model_card_load_button.py
@@ -7,6 +7,7 @@ from ..utils.model_card_utils import (
     delete_model_card_objects,
     update_model_card_objects,
     store_visibility_settings,
+    store_modifier_settings,
 )
 
 
@@ -30,6 +31,9 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
 
         # store visibility settings before deleting objects
         store_visibility_settings(model_card)
+
+        # store modifier settings before deleting objects
+        store_modifier_settings(model_card)
 
         delete_model_card_objects(model_card, context)
 

--- a/bpy_speckle/connector/blender_operators/model_card_load_button.py
+++ b/bpy_speckle/connector/blender_operators/model_card_load_button.py
@@ -6,8 +6,7 @@ from ..operations.load_operation import load_operation
 from ..utils.model_card_utils import (
     delete_model_card_objects,
     update_model_card_objects,
-    store_visibility_settings,
-    store_modifier_settings,
+    collect_objects_with_properties,
 )
 
 
@@ -29,8 +28,7 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
             self.report({"ERROR"}, "Model card not found")
             return {"CANCELLED"}
 
-        store_visibility_settings(model_card)
-        store_modifier_settings(model_card)
+        old_properties = collect_objects_with_properties(model_card)
         delete_model_card_objects(model_card, context)
 
         # set wm
@@ -52,7 +50,7 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
                 context, model_card.instance_loading_mode
             )
             # update model card details
-            update_model_card_objects(model_card, converted_objects)
+            update_model_card_objects(model_card, converted_objects, old_properties)
             model_card.version_id = latest_version_id
 
         else:
@@ -67,7 +65,7 @@ class SPECKLE_OT_load_model_card(bpy.types.Operator):
                 self.report({"ERROR"}, "Load operation failed")
                 return {"CANCELLED"}
             # update model card details
-            update_model_card_objects(model_card, converted_objects)
+            update_model_card_objects(model_card, converted_objects, old_properties)
 
         # Clear selected model details from Window Manager
         wm.selected_account_id = ""

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -103,7 +103,7 @@ def load_operation(
 
     traversal_function = create_default_traversal_function()
 
-    root_collection_name = f"{wm.selected_model_name} - {wm.selected_version_id[:8]}"
+    root_collection_name = f"{wm.selected_model_name} - {wm.selected_version_id}"
     root_collection = bpy.data.collections.new(root_collection_name)
     context.scene.collection.children.link(root_collection)
 
@@ -140,7 +140,7 @@ def load_operation(
                 speckle_root_id = speckle_obj.id
 
             collection_name = getattr(
-                speckle_obj, "name", f"Collection_{speckle_obj.id[:8]}"
+                speckle_obj, "name", f"Collection_{speckle_obj.id}"
             )
 
             parent_id = None

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -153,6 +153,7 @@ def load_operation(
                 "id": speckle_obj.id,
                 "name": collection_name,
                 "parent_id": parent_id,
+                "applicationId": getattr(speckle_obj, "applicationId", ""),
                 "blender_collection": None,
                 "full_path": [collection_name],
             }
@@ -208,6 +209,8 @@ def load_operation(
             blender_collection = created_collections[collection_key]
         else:
             blender_collection = bpy.data.collections.new(coll_name)
+            if coll_info.get("applicationId"):
+                blender_collection["applicationId"] = coll_info["applicationId"]
             parent_collection.children.link(blender_collection)
             created_collections[collection_key] = blender_collection
 

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -4,10 +4,34 @@ from typing import Dict
 from ..utils.property_groups import speckle_model_card
 
 
+def store_visibility_settings(model_card: speckle_model_card):
+    """
+    Store current visibility settings of model card objects
+    This is used to restore the visibility settings of the loaded objects after loading a new version
+    """
+    for s_obj in model_card.objects:
+        blender_obj = bpy.data.objects.get(s_obj.name)
+        if blender_obj:
+            s_obj.hide_get = blender_obj.hide_get()
+            s_obj.hide_viewport = blender_obj.hide_viewport
+            s_obj.hide_select = blender_obj.hide_select
+            s_obj.hide_render = blender_obj.hide_render
+
+
 def update_model_card_objects(
     model_card: speckle_model_card,
     converted_objects: Dict[str, bpy.types.Object | bpy.types.Collection],
 ):
+    # Store visibility settings from property group before clearing
+    visibility_settings = {}
+    for s_obj in model_card.objects:
+        visibility_settings[s_obj.name] = {
+            "hide_get": s_obj.hide_get,
+            "hide_viewport": s_obj.hide_viewport,
+            "hide_select": s_obj.hide_select,
+            "hide_render": s_obj.hide_render,
+        }
+
     # clear model card objects
     model_card.objects.clear()
     model_card.collections.clear()
@@ -30,13 +54,37 @@ def update_model_card_objects(
             s_obj = model_card.objects.add()
             s_obj.name = obj.name
 
+            # Restore visibility settings if they exist
+            if obj.name in visibility_settings:
+                s_obj.hide_get = visibility_settings[obj.name]["hide_get"]
+                s_obj.hide_viewport = visibility_settings[obj.name]["hide_viewport"]
+                s_obj.hide_select = visibility_settings[obj.name]["hide_select"]
+                s_obj.hide_render = visibility_settings[obj.name]["hide_render"]
+
+                # Apply the visibility settings to the new object
+                obj.hide_set(visibility_settings[obj.name]["hide_get"])
+                obj.hide_viewport = visibility_settings[obj.name]["hide_viewport"]
+                obj.hide_select = visibility_settings[obj.name]["hide_select"]
+                obj.hide_render = visibility_settings[obj.name]["hide_render"]
+
 
 def delete_model_card_objects(model_card: speckle_model_card, context: Context) -> None:
     """
     deletes the model card objects
     """
-    select_model_card_objects(model_card, context)
-    bpy.ops.object.delete()
+    # Delete objects directly without requiring selection
+    for obj in model_card.objects:
+        blender_obj = bpy.data.objects.get(obj.name)
+        if not blender_obj:
+            continue
+
+        # Remove object from all collections first
+        for collection in blender_obj.users_collection:
+            collection.objects.unlink(blender_obj)
+
+        # Delete the object directly
+        bpy.data.objects.remove(blender_obj)
+
     # delete model card/currently loaded collections
     for col in model_card.collections:
         coll = bpy.data.collections.get(col.name)

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -34,7 +34,6 @@ def get_object_by_application_id(app_id: str):
 def get_objects_by_application_ids(app_ids: list):
     """
     Find multiple Blender objects by their applicationIds
-    Returns a dictionary mapping applicationId to object
     """
     if not app_ids:
         return {}

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -4,9 +4,22 @@ from typing import Dict
 from ..utils.property_groups import speckle_model_card
 
 
+def find_layer_collection(layer_collection, collection_name):
+    """
+    Recursively find a layer collection by collection name
+    """
+    if layer_collection.collection.name == collection_name:
+        return layer_collection
+    for child in layer_collection.children:
+        result = find_layer_collection(child, collection_name)
+        if result:
+            return result
+    return None
+
+
 def store_visibility_settings(model_card: speckle_model_card):
     """
-    Store current visibility settings of model card objects
+    Store current visibility settings of model card objects and collections
     This is used to restore the visibility settings of the loaded objects after loading a new version
     """
     for s_obj in model_card.objects:
@@ -16,6 +29,27 @@ def store_visibility_settings(model_card: speckle_model_card):
             s_obj.hide_viewport = blender_obj.hide_viewport
             s_obj.hide_select = blender_obj.hide_select
             s_obj.hide_render = blender_obj.hide_render
+
+    for s_col in model_card.collections:
+        blender_col = bpy.data.collections.get(s_col.name)
+        if blender_col:
+            # For collections, visibility is controlled through the view layer system
+            view_layer = bpy.context.view_layer
+            if view_layer:
+                # Find the layer collection for this collection
+                layer_col = find_layer_collection(
+                    view_layer.layer_collection, blender_col.name
+                )
+                if layer_col:
+                    s_col.hide_viewport = layer_col.hide_viewport
+                    s_col.hide_select = layer_col.collection.hide_select
+                    s_col.hide_render = layer_col.collection.hide_render
+                    s_col.exclude_from_view_layer = layer_col.exclude
+                else:
+                    s_col.hide_viewport = False
+                    s_col.hide_select = False
+                    s_col.hide_render = False
+                    s_col.exclude_from_view_layer = False
 
 
 def update_model_card_objects(
@@ -30,6 +64,16 @@ def update_model_card_objects(
             "hide_viewport": s_obj.hide_viewport,
             "hide_select": s_obj.hide_select,
             "hide_render": s_obj.hide_render,
+        }
+
+    # Store collection visibility settings from property group before clearing
+    collection_visibility_settings = {}
+    for s_col in model_card.collections:
+        collection_visibility_settings[s_col.name] = {
+            "hide_viewport": s_col.hide_viewport,
+            "hide_select": s_col.hide_select,
+            "hide_render": s_col.hide_render,
+            "exclude_from_view_layer": s_col.exclude_from_view_layer,
         }
 
     # clear model card objects
@@ -47,6 +91,46 @@ def update_model_card_objects(
                 continue
             s_col = model_card.collections.add()
             s_col.name = obj.name
+
+            # Restore collection visibility settings if they exist
+            if obj.name in collection_visibility_settings:
+                s_col.hide_viewport = collection_visibility_settings[obj.name][
+                    "hide_viewport"
+                ]
+                s_col.hide_select = collection_visibility_settings[obj.name][
+                    "hide_select"
+                ]
+                s_col.hide_render = collection_visibility_settings[obj.name][
+                    "hide_render"
+                ]
+                s_col.exclude_from_view_layer = collection_visibility_settings[
+                    obj.name
+                ]["exclude_from_view_layer"]
+
+                # Apply the visibility settings to the new collection through view layer
+                view_layer = bpy.context.view_layer
+                if view_layer:
+                    # Find the layer collection for this collection
+                    layer_col = find_layer_collection(
+                        view_layer.layer_collection, obj.name
+                    )
+                    if layer_col:
+                        # Apply viewport visibility (controlled by layer collection)
+                        layer_col.hide_viewport = collection_visibility_settings[
+                            obj.name
+                        ]["hide_viewport"]
+                        # Apply selectability and render visibility (controlled by collection)
+                        obj.hide_select = collection_visibility_settings[obj.name][
+                            "hide_select"
+                        ]
+                        obj.hide_render = collection_visibility_settings[obj.name][
+                            "hide_render"
+                        ]
+                        # Apply view layer exclusion
+                        layer_col.exclude = collection_visibility_settings[obj.name][
+                            "exclude_from_view_layer"
+                        ]
+
         # if its an object, add it to the objects field of model card
         if isinstance(obj, bpy.types.Object):
             if obj.name in (o.name for o in model_card.objects):

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -121,23 +121,14 @@ def collect_objects_with_properties(
     """
     collected_data = {"objects": {}, "collections": {}}
 
-    # Metrics for optimization tracking
-    total_objects = 0
-    objects_with_visibility_mods = 0
-    objects_with_modifier_mods = 0
-    total_collections = 0
-    collections_with_mods = 0
-
     # Collect object properties (only for modified objects)
     for s_obj in model_card.objects:
         blender_obj = get_object_by_application_id(s_obj.applicationId)
         if blender_obj:
-            total_objects += 1
             obj_data = {}
 
             # Only collect visibility if modified from defaults
             if has_visibility_modifications(blender_obj):
-                objects_with_visibility_mods += 1
                 obj_data["visibility"] = {
                     "hide_get": blender_obj.hide_get(),
                     "hide_viewport": blender_obj.hide_viewport,
@@ -147,7 +138,6 @@ def collect_objects_with_properties(
 
             # Only collect modifiers if object has any
             if has_modifier_modifications(blender_obj):
-                objects_with_modifier_mods += 1
                 obj_data["modifiers"] = capture_modifier_data(blender_obj)
 
             # Only store object data if it has modifications
@@ -158,7 +148,6 @@ def collect_objects_with_properties(
     for s_col in model_card.collections:
         blender_col = bpy.data.collections.get(s_col.name)
         if blender_col:
-            total_collections += 1
             view_layer = bpy.context.view_layer
             if view_layer:
                 layer_col = find_layer_collection(
@@ -167,37 +156,12 @@ def collect_objects_with_properties(
                 if layer_col and has_collection_visibility_modifications(
                     layer_col, blender_col
                 ):
-                    collections_with_mods += 1
                     collected_data["collections"][s_col.name] = {
                         "hide_viewport": layer_col.hide_viewport,
                         "hide_select": layer_col.collection.hide_select,
                         "hide_render": layer_col.collection.hide_render,
                         "exclude_from_view_layer": layer_col.exclude,
                     }
-
-    # Optional logging of optimization metrics
-    if total_objects > 0 or total_collections > 0:
-        stored_objects = len(collected_data["objects"])
-        stored_collections = len(collected_data["collections"])
-
-        print("Property collection optimization:")
-        print(
-            f"  Objects: {stored_objects}/{total_objects} stored "
-            f"({(stored_objects/total_objects)*100:.1f}% with modifications)"
-        )
-        print(
-            f"    - Visibility: {objects_with_visibility_mods}/{total_objects} "
-            f"({(objects_with_visibility_mods/total_objects)*100:.1f}%)"
-        )
-        print(
-            f"    - Modifiers: {objects_with_modifier_mods}/{total_objects} "
-            f"({(objects_with_modifier_mods/total_objects)*100:.1f}%)"
-        )
-        if total_collections > 0:
-            print(
-                f"  Collections: {stored_collections}/{total_collections} stored "
-                f"({(stored_collections/total_collections)*100:.1f}% with modifications)"
-            )
 
     return collected_data
 

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -44,6 +44,41 @@ def get_objects_by_application_ids(app_ids: list):
     return result
 
 
+def get_collection_by_application_id(app_id: str):
+    """
+    Find a Blender collection by its applicationId stored in custom property
+    """
+    if not app_id:
+        return None
+
+    for collection in bpy.data.collections:
+        if "applicationId" in collection and collection["applicationId"] == app_id:
+            return collection
+    return None
+
+
+def get_collection_identifier(blender_col: bpy.types.Collection) -> str:
+    """
+    Get collection identifier: applicationId if exists, fallback to name
+    """
+    if "applicationId" in blender_col and blender_col["applicationId"]:
+        return blender_col["applicationId"]
+    return blender_col.name
+
+
+def find_collection_by_identifier(identifier: str):
+    """
+    Find collection by identifier: try applicationId first, then name
+    """
+    # first try to find by applicationId
+    collection = get_collection_by_application_id(identifier)
+    if collection:
+        return collection
+
+    # fallback to name-based lookup
+    return bpy.data.collections.get(identifier)
+
+
 def capture_modifier_data(blender_obj: bpy.types.Object) -> list:
     """
     Capture modifier data from a Blender object as dictionaries
@@ -146,7 +181,13 @@ def collect_objects_with_properties(
 
     # Collect collection properties (only for modified collections)
     for s_col in model_card.collections:
-        blender_col = bpy.data.collections.get(s_col.name)
+        # try to find collection by applicationId first, then fallback to name
+        blender_col = None
+        if s_col.applicationId:
+            blender_col = get_collection_by_application_id(s_col.applicationId)
+        if not blender_col:
+            blender_col = bpy.data.collections.get(s_col.name)
+
         if blender_col:
             view_layer = bpy.context.view_layer
             if view_layer:
@@ -156,7 +197,9 @@ def collect_objects_with_properties(
                 if layer_col and has_collection_visibility_modifications(
                     layer_col, blender_col
                 ):
-                    collected_data["collections"][s_col.name] = {
+                    # use collection identifier as key
+                    collection_id = get_collection_identifier(blender_col)
+                    collected_data["collections"][collection_id] = {
                         "hide_viewport": layer_col.hide_viewport,
                         "hide_select": layer_col.collection.hide_select,
                         "hide_render": layer_col.collection.hide_render,
@@ -280,11 +323,14 @@ def update_model_card_objects(
                 continue
             s_col = model_card.collections.add()
             s_col.name = obj.name
+            s_col.applicationId = obj.get("applicationId", "")
 
-            # Apply old collection properties if available
-            if old_properties and obj.name in old_properties.get("collections", {}):
-                old_col_data = old_properties["collections"][obj.name]
-                transfer_collection_properties(obj, old_col_data)
+            # apply old collection properties if available (use identifier-based lookup)
+            if old_properties:
+                collection_id = get_collection_identifier(obj)
+                if collection_id in old_properties.get("collections", {}):
+                    old_col_data = old_properties["collections"][collection_id]
+                    transfer_collection_properties(obj, old_col_data)
 
         # Handle objects
         elif isinstance(obj, bpy.types.Object):

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -1,6 +1,6 @@
 import bpy
 from bpy.types import Context
-from typing import Dict
+from typing import Dict, Any, Optional
 import json
 from ..utils.property_groups import speckle_model_card
 
@@ -272,7 +272,7 @@ def model_card_exists(
     return False
 
 
-def serialize_modifier(modifier):
+def serialize_modifier(modifier: bpy.types.Modifier) -> Dict[str, Any]:
     """
     Serialize a Blender modifier to a dictionary
     """
@@ -316,7 +316,7 @@ def serialize_modifier(modifier):
     return modifier_data
 
 
-def deserialize_modifier(obj, modifier_data):
+def deserialize_modifier(obj: bpy.types.Object, modifier_data: Dict[str, Any]) -> Optional[bpy.types.Modifier]:
     """
     Recreate a modifier from serialized data
     """
@@ -351,7 +351,7 @@ def deserialize_modifier(obj, modifier_data):
         return None
 
 
-def store_modifier_settings(model_card: speckle_model_card):
+def store_modifier_settings(model_card: speckle_model_card) -> None:
     """
     Store current modifier settings of model card objects
     This is used to restore the modifier settings of the loaded objects after loading a new version
@@ -368,7 +368,7 @@ def store_modifier_settings(model_card: speckle_model_card):
             s_obj.modifiers = json.dumps(modifiers_data)
 
 
-def restore_modifier_settings(blender_obj, modifier_data_json):
+def restore_modifier_settings(blender_obj: bpy.types.Object, modifier_data_json: str) -> None:
     """
     Restore modifier settings to a Blender object
     """

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -1,7 +1,6 @@
 import bpy
 from bpy.types import Context
 from typing import Dict, Any, Optional
-import json
 from ..utils.property_groups import speckle_model_card
 
 
@@ -45,163 +44,228 @@ def get_objects_by_application_ids(app_ids: list):
     return result
 
 
-def store_visibility_settings(model_card: speckle_model_card):
+def capture_modifier_data(blender_obj: bpy.types.Object) -> list:
     """
-    Store current visibility settings of model card objects and collections
-    This is used to restore the visibility settings of the loaded objects after loading a new version
+    Capture modifier data from a Blender object as dictionaries
     """
+    modifiers_data = []
+    for modifier in blender_obj.modifiers:
+        modifier_data = {
+            "name": modifier.name,
+            "type": modifier.type,
+            "show_viewport": modifier.show_viewport,
+            "show_render": modifier.show_render,
+            "show_in_editmode": modifier.show_in_editmode,
+            "show_on_cage": modifier.show_on_cage,
+            "properties": {},
+        }
+
+        # Capture modifier-specific properties
+        for prop_name in modifier.bl_rna.properties.keys():
+            if prop_name in [
+                "rna_type",
+                "name",
+                "type",
+                "show_viewport",
+                "show_render",
+                "show_in_editmode",
+                "show_on_cage",
+            ]:
+                continue
+            try:
+                if hasattr(modifier, prop_name):
+                    prop_value = getattr(modifier, prop_name)
+                    # Handle different property types
+                    if isinstance(prop_value, (int, float, bool, str)):
+                        modifier_data["properties"][prop_name] = prop_value
+                    elif hasattr(prop_value, "name"):  # Object references
+                        modifier_data["properties"][prop_name] = prop_value.name
+                    elif (
+                        hasattr(prop_value, "__len__") and len(prop_value) <= 4
+                    ):  # Vectors/colors
+                        modifier_data["properties"][prop_name] = list(prop_value)
+            except (AttributeError, TypeError):
+                continue
+
+        modifiers_data.append(modifier_data)
+
+    return modifiers_data
+
+
+def collect_objects_with_properties(
+    model_card: speckle_model_card,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Collect objects and collections with their current properties before deletion
+    """
+    collected_data = {"objects": {}, "collections": {}}
+
+    # Collect object properties
     for s_obj in model_card.objects:
         blender_obj = get_object_by_application_id(s_obj.applicationId)
         if blender_obj:
-            s_obj.hide_get = blender_obj.hide_get()
-            s_obj.hide_viewport = blender_obj.hide_viewport
-            s_obj.hide_select = blender_obj.hide_select
-            s_obj.hide_render = blender_obj.hide_render
+            collected_data["objects"][s_obj.applicationId] = {
+                "visibility": {
+                    "hide_get": blender_obj.hide_get(),
+                    "hide_viewport": blender_obj.hide_viewport,
+                    "hide_select": blender_obj.hide_select,
+                    "hide_render": blender_obj.hide_render,
+                },
+                "modifiers": capture_modifier_data(blender_obj)
+                if hasattr(blender_obj, "modifiers")
+                else [],
+            }
 
+    # Collect collection properties
     for s_col in model_card.collections:
         blender_col = bpy.data.collections.get(s_col.name)
         if blender_col:
-            # For collections, visibility is controlled through the view layer system
             view_layer = bpy.context.view_layer
             if view_layer:
-                # Find the layer collection for this collection
                 layer_col = find_layer_collection(
                     view_layer.layer_collection, blender_col.name
                 )
                 if layer_col:
-                    s_col.hide_viewport = layer_col.hide_viewport
-                    s_col.hide_select = layer_col.collection.hide_select
-                    s_col.hide_render = layer_col.collection.hide_render
-                    s_col.exclude_from_view_layer = layer_col.exclude
-                else:
-                    s_col.hide_viewport = False
-                    s_col.hide_select = False
-                    s_col.hide_render = False
-                    s_col.exclude_from_view_layer = False
+                    collected_data["collections"][s_col.name] = {
+                        "hide_viewport": layer_col.hide_viewport,
+                        "hide_select": layer_col.collection.hide_select,
+                        "hide_render": layer_col.collection.hide_render,
+                        "exclude_from_view_layer": layer_col.exclude,
+                    }
+
+    return collected_data
+
+
+def transfer_object_properties(
+    new_obj: bpy.types.Object, old_obj_data: Dict[str, Any]
+) -> None:
+    """
+    Transfer visibility and modifiers from old object data to new object
+    """
+    # Transfer visibility settings
+    visibility = old_obj_data.get("visibility", {})
+    if visibility:
+        new_obj.hide_set(visibility.get("hide_get", False))
+        new_obj.hide_viewport = visibility.get("hide_viewport", False)
+        new_obj.hide_select = visibility.get("hide_select", False)
+        new_obj.hide_render = visibility.get("hide_render", False)
+
+    # Transfer modifiers
+    old_modifiers = old_obj_data.get("modifiers", [])
+    if old_modifiers and hasattr(new_obj, "modifiers"):
+        # Clear existing modifiers
+        new_obj.modifiers.clear()
+
+        # Transfer each modifier
+        for modifier_data in old_modifiers:
+            recreate_modifier_from_data(new_obj, modifier_data)
+
+
+def transfer_collection_properties(
+    new_col: bpy.types.Collection, old_col_data: Dict[str, Any]
+) -> None:
+    """
+    Transfer visibility properties from old collection data to new collection
+    """
+    view_layer = bpy.context.view_layer
+    if view_layer:
+        layer_col = find_layer_collection(view_layer.layer_collection, new_col.name)
+        if layer_col:
+            layer_col.hide_viewport = old_col_data.get("hide_viewport", False)
+            layer_col.collection.hide_select = old_col_data.get("hide_select", False)
+            layer_col.collection.hide_render = old_col_data.get("hide_render", False)
+            layer_col.exclude = old_col_data.get("exclude_from_view_layer", False)
+
+
+def recreate_modifier_from_data(
+    new_obj: bpy.types.Object, modifier_data: Dict[str, Any]
+) -> Optional[bpy.types.Modifier]:
+    """
+    Recreate a modifier from captured data
+    """
+    try:
+        # Validate modifier data
+        if not modifier_data.get("type") or not modifier_data.get("name"):
+            print(f"Invalid modifier data: {modifier_data}")
+            return None
+
+        # Create new modifier
+        new_modifier = new_obj.modifiers.new(
+            modifier_data["name"], modifier_data["type"]
+        )
+
+        # Set visibility properties
+        new_modifier.show_viewport = modifier_data.get("show_viewport", True)
+        new_modifier.show_render = modifier_data.get("show_render", True)
+        new_modifier.show_in_editmode = modifier_data.get("show_in_editmode", True)
+        new_modifier.show_on_cage = modifier_data.get("show_on_cage", False)
+
+        # Set modifier-specific properties
+        for prop_name, prop_value in modifier_data.get("properties", {}).items():
+            try:
+                if hasattr(new_modifier, prop_name):
+                    current_value = getattr(new_modifier, prop_name)
+                    # Handle object references
+                    if hasattr(current_value, "name") and isinstance(prop_value, str):
+                        referenced_obj = bpy.data.objects.get(prop_value)
+                        if referenced_obj:
+                            setattr(new_modifier, prop_name, referenced_obj)
+                    else:
+                        setattr(new_modifier, prop_name, prop_value)
+            except (AttributeError, TypeError):
+                continue
+
+        return new_modifier
+    except Exception as e:
+        print(f"Error recreating modifier {modifier_data.get('name', 'unknown')}: {e}")
+        return None
 
 
 def update_model_card_objects(
     model_card: speckle_model_card,
     converted_objects: Dict[str, bpy.types.Object | bpy.types.Collection],
+    old_properties: Optional[Dict[str, Dict[str, Any]]] = None,
 ):
-    # Store visibility settings from property group before clearing
-    visibility_settings = {}
-    for s_obj in model_card.objects:
-        if s_obj.applicationId:
-            visibility_settings[s_obj.applicationId] = {
-                "hide_get": s_obj.hide_get,
-                "hide_viewport": s_obj.hide_viewport,
-                "hide_select": s_obj.hide_select,
-                "hide_render": s_obj.hide_render,
-            }
-
-    # Store modifier settings from property group before clearing
-    modifier_settings = {}
-    for s_obj in model_card.objects:
-        if s_obj.applicationId:
-            modifier_settings[s_obj.applicationId] = s_obj.modifiers
-
-    # Store collection visibility settings from property group before clearing
-    collection_visibility_settings = {}
-    for s_col in model_card.collections:
-        collection_visibility_settings[s_col.name] = {
-            "hide_viewport": s_col.hide_viewport,
-            "hide_select": s_col.hide_select,
-            "hide_render": s_col.hide_render,
-            "exclude_from_view_layer": s_col.exclude_from_view_layer,
-        }
-
-    # clear model card objects
+    """
+    Update model card with new objects and apply properties from old objects if provided
+    """
+    # Clear model card objects
     model_card.objects.clear()
     model_card.collections.clear()
 
-    # if converted_objects is a list, convert it to a dictionary
+    # Convert list to dictionary if needed
     if isinstance(converted_objects, list):
         converted_objects = {obj.name: obj for obj in converted_objects}
 
     for obj in converted_objects.values():
-        # if its a collection, add it to collections field of model card
+        # Handle collections
         if isinstance(obj, bpy.types.Collection):
             if obj.name in (o.name for o in model_card.collections):
                 continue
             s_col = model_card.collections.add()
             s_col.name = obj.name
 
-            # Restore collection visibility settings if they exist
-            if obj.name in collection_visibility_settings:
-                s_col.hide_viewport = collection_visibility_settings[obj.name][
-                    "hide_viewport"
-                ]
-                s_col.hide_select = collection_visibility_settings[obj.name][
-                    "hide_select"
-                ]
-                s_col.hide_render = collection_visibility_settings[obj.name][
-                    "hide_render"
-                ]
-                s_col.exclude_from_view_layer = collection_visibility_settings[
-                    obj.name
-                ]["exclude_from_view_layer"]
+            # Apply old collection properties if available
+            if old_properties and obj.name in old_properties.get("collections", {}):
+                old_col_data = old_properties["collections"][obj.name]
+                transfer_collection_properties(obj, old_col_data)
 
-                # Apply the visibility settings to the new collection through view layer
-                view_layer = bpy.context.view_layer
-                if view_layer:
-                    # Find the layer collection for this collection
-                    layer_col = find_layer_collection(
-                        view_layer.layer_collection, obj.name
-                    )
-                    if layer_col:
-                        # Apply viewport visibility (controlled by layer collection)
-                        layer_col.hide_viewport = collection_visibility_settings[
-                            obj.name
-                        ]["hide_viewport"]
-                        # Apply selectability and render visibility (controlled by collection)
-                        obj.hide_select = collection_visibility_settings[obj.name][
-                            "hide_select"
-                        ]
-                        obj.hide_render = collection_visibility_settings[obj.name][
-                            "hide_render"
-                        ]
-                        # Apply view layer exclusion
-                        layer_col.exclude = collection_visibility_settings[obj.name][
-                            "exclude_from_view_layer"
-                        ]
-
-        # if its an object, add it to the objects field of model card
-        if isinstance(obj, bpy.types.Object):
+        # Handle objects
+        elif isinstance(obj, bpy.types.Object):
             if obj.name in (o.name for o in model_card.objects):
                 continue
             s_obj = model_card.objects.add()
             s_obj.name = obj.name
             s_obj.applicationId = obj.get("applicationId", "")
-            # Restore visibility settings if they exist
-            if s_obj.applicationId and s_obj.applicationId in visibility_settings:
-                s_obj.hide_get = visibility_settings[s_obj.applicationId]["hide_get"]
-                s_obj.hide_viewport = visibility_settings[s_obj.applicationId][
-                    "hide_viewport"
-                ]
-                s_obj.hide_select = visibility_settings[s_obj.applicationId][
-                    "hide_select"
-                ]
-                s_obj.hide_render = visibility_settings[s_obj.applicationId][
-                    "hide_render"
-                ]
 
-                # Apply the visibility settings to the new object
-                obj.hide_set(visibility_settings[s_obj.applicationId]["hide_get"])
-                obj.hide_viewport = visibility_settings[s_obj.applicationId][
-                    "hide_viewport"
-                ]
-                obj.hide_select = visibility_settings[s_obj.applicationId][
-                    "hide_select"
-                ]
-                obj.hide_render = visibility_settings[s_obj.applicationId][
-                    "hide_render"
-                ]
-
-            # Restore modifier settings if they exist
-            if s_obj.applicationId and s_obj.applicationId in modifier_settings:
-                s_obj.modifiers = modifier_settings[s_obj.applicationId]
-                restore_modifier_settings(obj, modifier_settings[s_obj.applicationId])
+            # Apply old object properties if available
+            if (
+                old_properties
+                and s_obj.applicationId
+                and s_obj.applicationId in old_properties.get("objects", {})
+            ):
+                old_obj_data = old_properties["objects"][s_obj.applicationId]
+                transfer_object_properties(obj, old_obj_data)
 
 
 def delete_model_card_objects(model_card: speckle_model_card, context: Context) -> None:
@@ -270,120 +334,3 @@ def model_card_exists(
         ):
             return True
     return False
-
-
-def serialize_modifier(modifier: bpy.types.Modifier) -> Dict[str, Any]:
-    """
-    Serialize a Blender modifier to a dictionary
-    """
-    modifier_data = {
-        "name": modifier.name,
-        "type": modifier.type,
-        "show_viewport": modifier.show_viewport,
-        "show_render": modifier.show_render,
-        "show_in_editmode": modifier.show_in_editmode,
-        "show_on_cage": modifier.show_on_cage,
-        "properties": {},
-    }
-
-    # Store all modifier-specific properties
-    for prop_name in modifier.bl_rna.properties.keys():
-        if prop_name in [
-            "rna_type",
-            "name",
-            "type",
-            "show_viewport",
-            "show_render",
-            "show_in_editmode",
-            "show_on_cage",
-        ]:
-            continue
-        try:
-            prop_value = getattr(modifier, prop_name)
-            # Handle different property types
-            if isinstance(prop_value, (int, float, bool, str)):
-                modifier_data["properties"][prop_name] = prop_value
-            elif hasattr(prop_value, "name"):  # Object references
-                modifier_data["properties"][prop_name] = prop_value.name
-            elif (
-                hasattr(prop_value, "__len__") and len(prop_value) <= 4
-            ):  # Vectors/colors
-                modifier_data["properties"][prop_name] = list(prop_value)
-        except (AttributeError, TypeError):
-            # Skip properties that can't be serialized
-            continue
-
-    return modifier_data
-
-
-def deserialize_modifier(obj: bpy.types.Object, modifier_data: Dict[str, Any]) -> Optional[bpy.types.Modifier]:
-    """
-    Recreate a modifier from serialized data
-    """
-    try:
-        modifier = obj.modifiers.new(modifier_data["name"], modifier_data["type"])
-
-        # Set visibility properties
-        modifier.show_viewport = modifier_data.get("show_viewport", True)
-        modifier.show_render = modifier_data.get("show_render", True)
-        modifier.show_in_editmode = modifier_data.get("show_in_editmode", True)
-        modifier.show_on_cage = modifier_data.get("show_on_cage", False)
-
-        # Set modifier-specific properties
-        for prop_name, prop_value in modifier_data.get("properties", {}).items():
-            try:
-                if hasattr(modifier, prop_name):
-                    current_value = getattr(modifier, prop_name)
-                    # Handle object references
-                    if hasattr(current_value, "name") and isinstance(prop_value, str):
-                        referenced_obj = bpy.data.objects.get(prop_value)
-                        if referenced_obj:
-                            setattr(modifier, prop_name, referenced_obj)
-                    else:
-                        setattr(modifier, prop_name, prop_value)
-            except (AttributeError, TypeError):
-                # Skip properties that can't be set
-                continue
-
-        return modifier
-    except Exception as e:
-        print(f"Error deserializing modifier {modifier_data['name']}: {e}")
-        return None
-
-
-def store_modifier_settings(model_card: speckle_model_card) -> None:
-    """
-    Store current modifier settings of model card objects
-    This is used to restore the modifier settings of the loaded objects after loading a new version
-    """
-    for s_obj in model_card.objects:
-        blender_obj = get_object_by_application_id(s_obj.applicationId)
-        if blender_obj and hasattr(blender_obj, "modifiers"):
-            modifiers_data = []
-            for modifier in blender_obj.modifiers:
-                modifier_data = serialize_modifier(modifier)
-                modifiers_data.append(modifier_data)
-
-            # Store as JSON string
-            s_obj.modifiers = json.dumps(modifiers_data)
-
-
-def restore_modifier_settings(blender_obj: bpy.types.Object, modifier_data_json: str) -> None:
-    """
-    Restore modifier settings to a Blender object
-    """
-    if not modifier_data_json or not hasattr(blender_obj, "modifiers"):
-        return
-
-    try:
-        modifiers_data = json.loads(modifier_data_json)
-
-        # Clear existing modifiers
-        blender_obj.modifiers.clear()
-
-        # Recreate modifiers
-        for modifier_data in modifiers_data:
-            deserialize_modifier(blender_obj, modifier_data)
-
-    except (json.JSONDecodeError, KeyError, TypeError) as e:
-        print(f"Error restoring modifiers for {blender_obj.name}: {e}")

--- a/bpy_speckle/connector/utils/model_card_utils.py
+++ b/bpy_speckle/connector/utils/model_card_utils.py
@@ -92,46 +92,112 @@ def capture_modifier_data(blender_obj: bpy.types.Object) -> list:
     return modifiers_data
 
 
+def has_visibility_modifications(obj: bpy.types.Object) -> bool:
+    """Check if object has non-default visibility settings"""
+    return obj.hide_viewport or obj.hide_select or obj.hide_render or obj.hide_get()
+
+
+def has_modifier_modifications(obj: bpy.types.Object) -> bool:
+    """Check if object has any modifiers applied"""
+    return hasattr(obj, "modifiers") and len(obj.modifiers) > 0
+
+
+def has_collection_visibility_modifications(layer_col, collection) -> bool:
+    """Check if collection has non-default visibility settings"""
+    return (
+        layer_col.hide_viewport
+        or collection.hide_select
+        or collection.hide_render
+        or layer_col.exclude
+    )
+
+
 def collect_objects_with_properties(
     model_card: speckle_model_card,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Collect objects and collections with their current properties before deletion
+    Only stores data for objects that have been modified from defaults
     """
     collected_data = {"objects": {}, "collections": {}}
 
-    # Collect object properties
+    # Metrics for optimization tracking
+    total_objects = 0
+    objects_with_visibility_mods = 0
+    objects_with_modifier_mods = 0
+    total_collections = 0
+    collections_with_mods = 0
+
+    # Collect object properties (only for modified objects)
     for s_obj in model_card.objects:
         blender_obj = get_object_by_application_id(s_obj.applicationId)
         if blender_obj:
-            collected_data["objects"][s_obj.applicationId] = {
-                "visibility": {
+            total_objects += 1
+            obj_data = {}
+
+            # Only collect visibility if modified from defaults
+            if has_visibility_modifications(blender_obj):
+                objects_with_visibility_mods += 1
+                obj_data["visibility"] = {
                     "hide_get": blender_obj.hide_get(),
                     "hide_viewport": blender_obj.hide_viewport,
                     "hide_select": blender_obj.hide_select,
                     "hide_render": blender_obj.hide_render,
-                },
-                "modifiers": capture_modifier_data(blender_obj)
-                if hasattr(blender_obj, "modifiers")
-                else [],
-            }
+                }
 
-    # Collect collection properties
+            # Only collect modifiers if object has any
+            if has_modifier_modifications(blender_obj):
+                objects_with_modifier_mods += 1
+                obj_data["modifiers"] = capture_modifier_data(blender_obj)
+
+            # Only store object data if it has modifications
+            if obj_data:
+                collected_data["objects"][s_obj.applicationId] = obj_data
+
+    # Collect collection properties (only for modified collections)
     for s_col in model_card.collections:
         blender_col = bpy.data.collections.get(s_col.name)
         if blender_col:
+            total_collections += 1
             view_layer = bpy.context.view_layer
             if view_layer:
                 layer_col = find_layer_collection(
                     view_layer.layer_collection, blender_col.name
                 )
-                if layer_col:
+                if layer_col and has_collection_visibility_modifications(
+                    layer_col, blender_col
+                ):
+                    collections_with_mods += 1
                     collected_data["collections"][s_col.name] = {
                         "hide_viewport": layer_col.hide_viewport,
                         "hide_select": layer_col.collection.hide_select,
                         "hide_render": layer_col.collection.hide_render,
                         "exclude_from_view_layer": layer_col.exclude,
                     }
+
+    # Optional logging of optimization metrics
+    if total_objects > 0 or total_collections > 0:
+        stored_objects = len(collected_data["objects"])
+        stored_collections = len(collected_data["collections"])
+
+        print("Property collection optimization:")
+        print(
+            f"  Objects: {stored_objects}/{total_objects} stored "
+            f"({(stored_objects/total_objects)*100:.1f}% with modifications)"
+        )
+        print(
+            f"    - Visibility: {objects_with_visibility_mods}/{total_objects} "
+            f"({(objects_with_visibility_mods/total_objects)*100:.1f}%)"
+        )
+        print(
+            f"    - Modifiers: {objects_with_modifier_mods}/{total_objects} "
+            f"({(objects_with_modifier_mods/total_objects)*100:.1f}%)"
+        )
+        if total_collections > 0:
+            print(
+                f"  Collections: {stored_collections}/{total_collections} stored "
+                f"({(stored_collections/total_collections)*100:.1f}% with modifications)"
+            )
 
     return collected_data
 
@@ -141,17 +207,19 @@ def transfer_object_properties(
 ) -> None:
     """
     Transfer visibility and modifiers from old object data to new object
+    Handles sparse data gracefully - applies defaults when data is missing
     """
-    # Transfer visibility settings
-    visibility = old_obj_data.get("visibility", {})
+    # Transfer visibility settings (if any were modified)
+    visibility = old_obj_data.get("visibility")
     if visibility:
         new_obj.hide_set(visibility.get("hide_get", False))
         new_obj.hide_viewport = visibility.get("hide_viewport", False)
         new_obj.hide_select = visibility.get("hide_select", False)
         new_obj.hide_render = visibility.get("hide_render", False)
+    # If no visibility data, object keeps defaults (all False)
 
-    # Transfer modifiers
-    old_modifiers = old_obj_data.get("modifiers", [])
+    # Transfer modifiers (if any were present)
+    old_modifiers = old_obj_data.get("modifiers")
     if old_modifiers and hasattr(new_obj, "modifiers"):
         # Clear existing modifiers
         new_obj.modifiers.clear()
@@ -159,6 +227,7 @@ def transfer_object_properties(
         # Transfer each modifier
         for modifier_data in old_modifiers:
             recreate_modifier_from_data(new_obj, modifier_data)
+    # If no modifier data, object keeps default (no modifiers)
 
 
 def transfer_collection_properties(
@@ -166,11 +235,14 @@ def transfer_collection_properties(
 ) -> None:
     """
     Transfer visibility properties from old collection data to new collection
+    Handles sparse data gracefully - applies defaults when data is missing
     """
     view_layer = bpy.context.view_layer
     if view_layer:
         layer_col = find_layer_collection(view_layer.layer_collection, new_col.name)
         if layer_col:
+            # Only apply properties if collection had modifications
+            # (otherwise it keeps defaults: all False)
             layer_col.hide_viewport = old_col_data.get("hide_viewport", False)
             layer_col.collection.hide_select = old_col_data.get("hide_select", False)
             layer_col.collection.hide_render = old_col_data.get("hide_render", False)

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -1,5 +1,4 @@
 import bpy
-from typing import Dict, Any
 
 
 class speckle_project(bpy.types.PropertyGroup):
@@ -37,10 +36,14 @@ class speckle_version(bpy.types.PropertyGroup):
 
 class speckle_object(bpy.types.PropertyGroup):
     """
-    PropertyGroup for storing object names
+    PropertyGroup for storing object names and visibility settings
     """
 
     name: bpy.props.StringProperty()  # type: ignore
+    hide_get: bpy.props.BoolProperty(name="Hide Get", default=False)  # type: ignore
+    hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
+    hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore
+    hide_render: bpy.props.BoolProperty(name="Hide Render", default=False)  # type: ignore
 
 
 class speckle_collection(bpy.types.PropertyGroup):

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -48,10 +48,16 @@ class speckle_object(bpy.types.PropertyGroup):
 
 class speckle_collection(bpy.types.PropertyGroup):
     """
-    PropertyGroup for storing collection information
+    PropertyGroup for storing collection information and visibility settings
     """
 
     name: bpy.props.StringProperty()  # type: ignore
+    hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
+    hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore
+    hide_render: bpy.props.BoolProperty(name="Hide Render", default=False)  # type: ignore
+    exclude_from_view_layer: bpy.props.BoolProperty(
+        name="Exclude From View Layer", default=False
+    )  # type: ignore
 
 
 class speckle_model_card(bpy.types.PropertyGroup):

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -44,6 +44,7 @@ class speckle_object(bpy.types.PropertyGroup):
     hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
     hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore
     hide_render: bpy.props.BoolProperty(name="Hide Render", default=False)  # type: ignore
+    modifiers: bpy.props.StringProperty(name="Modifiers", default="")  # type: ignore
 
 
 class speckle_collection(bpy.types.PropertyGroup):

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -40,6 +40,7 @@ class speckle_object(bpy.types.PropertyGroup):
     """
 
     name: bpy.props.StringProperty()  # type: ignore
+    applicationId: bpy.props.StringProperty(name="Application ID", default="")  # type: ignore
     hide_get: bpy.props.BoolProperty(name="Hide Get", default=False)  # type: ignore
     hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
     hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -36,30 +36,19 @@ class speckle_version(bpy.types.PropertyGroup):
 
 class speckle_object(bpy.types.PropertyGroup):
     """
-    PropertyGroup for storing object names and visibility settings
+    PropertyGroup for storing object names and applicationIds
     """
 
     name: bpy.props.StringProperty()  # type: ignore
     applicationId: bpy.props.StringProperty(name="Application ID", default="")  # type: ignore
-    hide_get: bpy.props.BoolProperty(name="Hide Get", default=False)  # type: ignore
-    hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
-    hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore
-    hide_render: bpy.props.BoolProperty(name="Hide Render", default=False)  # type: ignore
-    modifiers: bpy.props.StringProperty(name="Modifiers", default="")  # type: ignore
 
 
 class speckle_collection(bpy.types.PropertyGroup):
     """
-    PropertyGroup for storing collection information and visibility settings
+    PropertyGroup for storing collections
     """
 
     name: bpy.props.StringProperty()  # type: ignore
-    hide_viewport: bpy.props.BoolProperty(name="Hide Viewport", default=False)  # type: ignore
-    hide_select: bpy.props.BoolProperty(name="Hide Select", default=False)  # type: ignore
-    hide_render: bpy.props.BoolProperty(name="Hide Render", default=False)  # type: ignore
-    exclude_from_view_layer: bpy.props.BoolProperty(
-        name="Exclude From View Layer", default=False
-    )  # type: ignore
 
 
 class speckle_model_card(bpy.types.PropertyGroup):

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -49,6 +49,7 @@ class speckle_collection(bpy.types.PropertyGroup):
     """
 
     name: bpy.props.StringProperty()  # type: ignore
+    applicationId: bpy.props.StringProperty(name="Application ID", default="")  # type: ignore
 
 
 class speckle_model_card(bpy.types.PropertyGroup):

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -186,7 +186,7 @@ def convert_to_native(
         # Store Speckle ID in custom property
         converted_object["speckle_id"] = speckle_object.id
         if hasattr(speckle_object, "applicationId"):
-            converted_object["applicationId"] = speckle_object.applicationId
+            converted_object["speckle_application_id"] = speckle_object.applicationId
 
     return converted_object
 

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -320,7 +320,9 @@ def _members_to_native(
 
     for item in others:
         try:
-            blender_object = convert_to_native(item, material_mapping, instance_loading_mode="INSTANCE_PROXIES")
+            blender_object = convert_to_native(
+                item, material_mapping, instance_loading_mode="INSTANCE_PROXIES"
+            )
             if blender_object:
                 # If the parent is a DataObject, override the name of the converted child
                 if is_data_object:
@@ -1219,7 +1221,7 @@ def instance_definition_proxy_to_native(
         "Must be 'INSTANCE_PROXIES' or 'LINKED_DUPLICATES'"
     )
     assert isinstance(material_mapping, dict), "material_mapping must be a dictionary"
-    
+
     processed_definitions = processed_definitions or {}
     definition_collections = {}
     converted_objects = {}
@@ -1240,7 +1242,7 @@ def instance_definition_proxy_to_native(
     sorted_components = sort_instance_components(definitions, [])
 
     for _, _, def_id, definition in sorted_components:
-        collection_name = getattr(definition, "name", f"Definition_{def_id[:8]}")
+        collection_name = getattr(definition, "name", f"Definition_{def_id}")
 
         if def_id in processed_definitions:
             definition_collections[def_id] = processed_definitions[def_id]
@@ -1272,10 +1274,10 @@ def instance_definition_proxy_to_native(
                             nested_def = definitions[found_obj.definitionId]
                             max_depth = getattr(nested_def, "maxDepth", 0)
                             if max_depth > 0:  # Only process if max_depth allows
-                                assert found_obj.definitionId in definition_collections, (
-                                    f"Definition collection not found for nested instance {found_obj.definitionId}"
-                                )
-                                
+                                assert (
+                                    found_obj.definitionId in definition_collections
+                                ), f"Definition collection not found for nested instance {found_obj.definitionId}"
+
                                 if instance_loading_mode == "LINKED_DUPLICATES":
                                     blender_obj = instance_proxy_to_linked_duplicates(
                                         found_obj,
@@ -1293,7 +1295,11 @@ def instance_definition_proxy_to_native(
                                 if blender_obj:
                                     converted_objects[obj_id] = blender_obj
                         else:
-                            blender_obj = convert_to_native(found_obj, material_mapping, instance_loading_mode="INSTANCE_PROXIES")
+                            blender_obj = convert_to_native(
+                                found_obj,
+                                material_mapping,
+                                instance_loading_mode="INSTANCE_PROXIES",
+                            )
                             if blender_obj:
                                 definition_collection.objects.link(blender_obj)
                                 converted_objects[obj_id] = blender_obj
@@ -1398,16 +1404,16 @@ def instance_proxy_to_linked_duplicates(
         @ mathutils.Matrix.Diagonal(scale_vector).to_4x4()
     )
 
-    instance_name = f"Instance_{speckle_instance.id[:8]}"
+    instance_name = f"Instance_{speckle_instance.id}"
     parent_empty = bpy.data.objects.new(instance_name, None)
-    parent_empty.empty_display_type = 'PLAIN_AXES'
+    parent_empty.empty_display_type = "PLAIN_AXES"
     parent_empty.empty_display_size = 0.1
-    
+
     parent_empty.matrix_world = final_matrix
-    
+
     # link parent to root collection
     root_collection.objects.link(parent_empty)
-    
+
     parent_empty["speckle_id"] = speckle_instance.id
     parent_empty["speckle_type"] = speckle_instance.speckle_type
     parent_empty["definition_id"] = speckle_instance.definitionId
@@ -1418,14 +1424,14 @@ def instance_proxy_to_linked_duplicates(
     for obj in definition_collection.objects:
         # create a copy of the object with linked data
         duplicate_obj = obj.copy()
-        
+
         duplicate_obj.name = f"{obj.name}_{speckle_instance.id[:8]}"
-        
+
         root_collection.objects.link(duplicate_obj)
-        
+
         # apply the instance transformation directly to each object
         duplicate_obj.matrix_world = final_matrix @ obj.matrix_world
-        
+
         duplicated_objects.append(duplicate_obj)
 
     return parent_empty
@@ -1492,7 +1498,7 @@ def instance_proxy_to_native(
 
     instance_obj.empty_display_size = 0
 
-    instance_name = f"Instance_{speckle_instance.id[:8]}"
+    instance_name = f"Instance_{speckle_instance.id}"
     instance_obj.name = instance_name
 
     if instance_obj.name not in root_collection.objects:

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -186,7 +186,7 @@ def convert_to_native(
         # Store Speckle ID in custom property
         converted_object["speckle_id"] = speckle_object.id
         if hasattr(speckle_object, "applicationId"):
-            converted_object["speckle_application_id"] = speckle_object.applicationId
+            converted_object["applicationId"] = speckle_object.applicationId
 
     return converted_object
 


### PR DESCRIPTION
This PR does 4 things:
- Removes the 8 char limit from model id because model id is 10 digit. We add all of it now.
- migrates the model card object tracking system from name-based to applicationId-based tracking to prevent issues when users rename objects in Blender.

    https://github.com/user-attachments/assets/79bd76fe-38cb-4895-a750-b627b6e3b56e
- preserve visibility changes made to the objects and collections by the user: when a new version is loaded, it will apply the same visibility settings if the application ids are the same.

    https://github.com/user-attachments/assets/7b093635-e1b5-4349-bc53-9b24967e4870
- preserves applied modifiers to objects: when a new version is loaded, it will apply the modifiers if the application ids are the same.

    https://github.com/user-attachments/assets/136a0b55-805f-4654-b442-744941920700