### PR TITLE
Load Properties in Blender

### DIFF
--- a/bpy_speckle/connector/blender_operators/load_button.py
+++ b/bpy_speckle/connector/blender_operators/load_button.py
@@ -20,7 +20,7 @@ class SPECKLE_OT_load(bpy.types.Operator):
         description="Choose how to load instances",
         items=[
             (
-                "INSTANCE_PROXIES",
+                "COLLECTION_INSTANCES",
                 "Collection Instances",
                 "Load objects as collection instances",
             ),
@@ -30,7 +30,7 @@ class SPECKLE_OT_load(bpy.types.Operator):
                 "Get objects as linked duplicates",
             ),
         ],
-        default="INSTANCE_PROXIES",
+        default="COLLECTION_INSTANCES",
     )
 
     def draw(self, context: Context) -> None:

--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -23,7 +23,7 @@ from typing import Dict, Union
 
 
 def load_operation(
-    context: Context, instance_loading_mode: str = "INSTANCE_PROXIES"
+    context: Context, instance_loading_mode: str = "COLLECTION_INSTANCES"
 ) -> Dict[str, Union[bpy.types.Collection, bpy.types.Object]]:
     """
     load objects from Speckle and maintain hierarchy.

--- a/bpy_speckle/connector/utils/property_groups.py
+++ b/bpy_speckle/connector/utils/property_groups.py
@@ -106,7 +106,7 @@ class speckle_model_card(bpy.types.PropertyGroup):
     instance_loading_mode: bpy.props.StringProperty(
         name="Instance Loading Mode",
         description="Mode of loading instances",
-        default="INSTANCE_PROXIES",
+        default="COLLECTION_INSTANCES",
     )  # type: ignore
     apply_modifiers: bpy.props.BoolProperty(
         name="Apply Modifiers",

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -233,6 +233,8 @@ def _traverse_properties(obj: Any, parent_name: str = "") -> Dict[str, Any]:
         # Skip excluded sections
         if key == "Material Quantities":
             continue
+        if key == "Composite Structure":
+            continue
         if parent_name == "Type Parameters" and key == "Structure":
             continue
             

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -203,12 +203,6 @@ def convert_to_native(
 def convert_property_value(value: Any) -> Any:
     """Convert property values to appropriate Python types."""
     if isinstance(value, str):
-        # Handle boolean strings
-        lower_value = value.lower()
-        if lower_value == "yes" or lower_value == "true":
-            return True
-        elif lower_value == "no" or lower_value == "false":
-            return False
         # Return string as-is
         return value
     elif isinstance(value, (int, float)):

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -85,7 +85,7 @@ def convert_to_native(
     material_mapping: Optional[Dict[str, bpy.types.Material]] = None,
     definition_collections: Optional[Dict[str, bpy.types.Collection]] = None,
     root_collection: Optional[bpy.types.Collection] = None,
-    instance_loading_mode: str = "INSTANCE_PROXIES",
+    instance_loading_mode: str = "COLLECTION_INSTANCES",
 ) -> Optional[Object]:
     """
     converts a speckle object to blender object with material support
@@ -114,7 +114,7 @@ def convert_to_native(
                         converted_object = instance_proxy_to_linked_duplicates(
                             speckle_object, coll, root_collection, scale
                         )
-                    else:  # INSTANCE_PROXIES (default)
+                    else:  # COLLECTION_INSTANCES (default)
                         converted_object = instance_proxy_to_native(
                             speckle_object, coll, root_collection, scale
                         )
@@ -407,7 +407,7 @@ def _members_to_native(
     for item in others:
         try:
             blender_object = convert_to_native(
-                item, material_mapping, instance_loading_mode="INSTANCE_PROXIES"
+                item, material_mapping, instance_loading_mode="COLLECTION_INSTANCES"
             )
             if blender_object:
                 # If the parent is a DataObject, override the name of the converted child
@@ -1296,13 +1296,13 @@ def instance_definition_proxy_to_native(
     root_object: Base,
     material_mapping: Dict[str, Any],
     processed_definitions: Dict[str, Any] = None,
-    instance_loading_mode: str = "INSTANCE_PROXIES",
+    instance_loading_mode: str = "COLLECTION_INSTANCES",
 ) -> Tuple[Dict[str, bpy.types.Collection], Dict[str, Any]]:
     """
     converts instance definition proxies to Blender collections recursively
     """
     # Validate instance loading mode
-    assert instance_loading_mode in ["INSTANCE_PROXIES", "LINKED_DUPLICATES"], (
+    assert instance_loading_mode in ["COLLECTION_INSTANCES", "LINKED_DUPLICATES"], (
         f"Invalid instance_loading_mode: {instance_loading_mode}. "
         "Must be 'INSTANCE_PROXIES' or 'LINKED_DUPLICATES'"
     )
@@ -1371,7 +1371,7 @@ def instance_definition_proxy_to_native(
                                         definition_collection,
                                         scale=1.0,
                                     )
-                                else:  # INSTANCE_PROXIES (default)
+                                else:  # COLLECTION_INSTANCES (default)
                                     blender_obj = instance_proxy_to_native(
                                         found_obj,
                                         definition_collections[found_obj.definitionId],
@@ -1384,7 +1384,7 @@ def instance_definition_proxy_to_native(
                             blender_obj = convert_to_native(
                                 found_obj,
                                 material_mapping,
-                                instance_loading_mode="INSTANCE_PROXIES",
+                                instance_loading_mode="COLLECTION_INSTANCES",
                             )
                             if blender_obj:
                                 definition_collection.objects.link(blender_obj)

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -187,7 +187,7 @@ def convert_to_native(
         converted_object["speckle_id"] = speckle_object.id
         if hasattr(speckle_object, "applicationId"):
             converted_object["applicationId"] = speckle_object.applicationId
-        
+
         # Extract and store Speckle properties
         speckle_properties = extract_speckle_properties(speckle_object)
         for prop_name, prop_value in speckle_properties.items():
@@ -219,10 +219,7 @@ def convert_property_value(value: Any) -> Any:
 def _traverse_properties(obj: Any, parent_name: str = "") -> Dict[str, Any]:
     """Recursively traverse properties, collecting name/value pairs with duplicate handling."""
     properties = {}
-    
-    if not isinstance(obj, dict):
-        return properties
-    
+
     for key, value in obj.items():
         # Skip excluded sections
         if key == "Material Quantities":
@@ -231,19 +228,19 @@ def _traverse_properties(obj: Any, parent_name: str = "") -> Dict[str, Any]:
             continue
         if parent_name == "Type Parameters" and key == "Structure":
             continue
-            
+
         if isinstance(value, dict):
             # Check if this is a complex property (has name and value)
             if "name" in value and "value" in value:
                 # Extract only name and value, ignore other fields
                 prop_name = value.get("name", key)
                 prop_value = convert_property_value(value["value"])
-                
+
                 # Handle duplicates by adding parent suffix
                 final_name = prop_name
                 if final_name in properties:
                     final_name = f"{prop_name}_{key}"  # Use the dict key as suffix
-                
+
                 properties[final_name] = prop_value
             else:
                 # Recurse into nested structure
@@ -253,32 +250,30 @@ def _traverse_properties(obj: Any, parent_name: str = "") -> Dict[str, Any]:
                     final_name = nested_name
                     if final_name in properties:
                         final_name = f"{nested_name}_{key}"
-                    
+
                     properties[final_name] = nested_value
         else:
             # Simple property - store directly with key as name
             final_name = key
             if final_name in properties:
                 final_name = f"{key}_{parent_name}" if parent_name else key
-            
+
             properties[final_name] = convert_property_value(value)
-    
+
     return properties
 
 
 def extract_speckle_properties(speckle_object: Base) -> Dict[str, Any]:
     """Extract properties from Speckle object properties field only."""
-    if not hasattr(speckle_object, "properties"):
+    if not isinstance(speckle_object, DataObject):
         return {}
-    
+
     try:
-        properties = speckle_object.properties
-        if isinstance(properties, dict):
-            return _traverse_properties(properties)
+        return _traverse_properties(speckle_object.properties)
     except Exception as e:
         # Silently handle any extraction errors
         print(f"Warning: Failed to extract properties: {e}")
-    
+
     return {}
 
 


### PR DESCRIPTION
# DO NOT MERGE BEFORE #290 🚩🚩🚩🚩

This PR implements property extraction from Speckle objects, and making them accessible as custom properties on Blender objects. When loading models from AEC applications like Revit, Archicad, Tekla and users now get rich property information.

- Added `extract_speckle_properties()`, `convert_property_value()` and `_traverse_properties()` functions.
- Modified `convert_to_native()` to extract and store properties as Blender custom properties
- Automatic data type detection:
    - Yes/No/True/False -> Boolean
    - Numbers -> Int/Float
    - Everything else -> Text
- Properties excluded: Material Quantities, Type Parameters :: Structure (Revit), Composite Structure (Archicad)

Archicad Wall
<img width="962" height="566" alt="SCR-20250711-ptfg" src="https://github.com/user-attachments/assets/7b52839f-4315-4f50-aedb-e313fde3f8ac" />

Revit Model
![SCR-20250711-ptjs](https://github.com/user-attachments/assets/b98fc4cc-ab00-468e-a279-a98f1bbc2fbd)

IFC Model
![SCR-20250711-puax](https://github.com/user-attachments/assets/d1004b1d-0504-4ffa-88cf-41c53e00687a)
