### PR TITLE
Support for IFC/Bonsai properties

### DIFF
--- a/bpy_speckle/converter/to_speckle/curve_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/curve_to_speckle.py
@@ -5,7 +5,7 @@ from specklepy.objects.primitive import Interval
 from specklepy.objects.base import Base
 from mathutils import Matrix
 from mathutils.geometry import interpolate_bezier
-from .utils import nurb_make_curve, make_knots, extract_custom_properties
+from .utils import nurb_make_curve, make_knots, apply_cached_properties, extract_custom_properties
 
 
 def curve_to_speckle(
@@ -21,7 +21,7 @@ def curve_to_speckle(
     base = Base()
     curves = []
 
-    # Extract custom properties from the curve data
+    # Extract custom properties once for all curves (shared curve data)
     curve_properties = extract_custom_properties(curve_data)
 
     for spline in curve_data.splines:
@@ -29,15 +29,13 @@ def curve_to_speckle(
             curve = bezier_to_speckle(
                 matrix, spline, blender_obj.name, scale_factor, units
             )
-            if curve_properties:
-                curve.properties = curve_properties
+            apply_cached_properties(curve, curve_properties)
             curves.append(curve)
         elif spline.type == "NURBS":
             curve = nurbs_to_speckle(
                 matrix, spline, blender_obj.name, scale_factor, units
             )
-            if curve_properties:
-                curve.properties = curve_properties
+            apply_cached_properties(curve, curve_properties)
             curves.append(curve)
 
     if curves:

--- a/bpy_speckle/converter/to_speckle/curve_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/curve_to_speckle.py
@@ -5,7 +5,7 @@ from specklepy.objects.primitive import Interval
 from specklepy.objects.base import Base
 from mathutils import Matrix
 from mathutils.geometry import interpolate_bezier
-from .utils import nurb_make_curve, make_knots
+from .utils import nurb_make_curve, make_knots, extract_custom_properties
 
 
 def curve_to_speckle(
@@ -21,15 +21,24 @@ def curve_to_speckle(
     base = Base()
     curves = []
 
+    # Extract custom properties from the curve data
+    curve_properties = extract_custom_properties(curve_data)
+
     for spline in curve_data.splines:
         if spline.type == "BEZIER":
-            curves.append(
-                bezier_to_speckle(matrix, spline, blender_obj.name, scale_factor, units)
+            curve = bezier_to_speckle(
+                matrix, spline, blender_obj.name, scale_factor, units
             )
+            if curve_properties:
+                curve.properties = curve_properties
+            curves.append(curve)
         elif spline.type == "NURBS":
-            curves.append(
-                nurbs_to_speckle(matrix, spline, blender_obj.name, scale_factor, units)
+            curve = nurbs_to_speckle(
+                matrix, spline, blender_obj.name, scale_factor, units
             )
+            if curve_properties:
+                curve.properties = curve_properties
+            curves.append(curve)
 
     if curves:
         base["@elements"] = curves

--- a/bpy_speckle/converter/to_speckle/ifc_properties.py
+++ b/bpy_speckle/converter/to_speckle/ifc_properties.py
@@ -2,8 +2,35 @@
 All IFC-related imports are wrapped in try-except blocks to ensure the code only runs when Bonsai/ifcopenshell is available.
 """
 
+from functools import lru_cache
 from typing import Dict, Any
 from bpy.types import Object
+
+
+@lru_cache(maxsize=1)
+def get_ifc_tool():
+    """
+    Get the Bonsai IFC tool with caching to improve performance.
+    """
+    try:
+        import bonsai.tool as tool
+
+        return tool
+    except ImportError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_ifcopenshell_util_element():
+    """
+    Get the ifcopenshell.util.element module with caching to improve performance.
+    """
+    try:
+        import ifcopenshell.util.element
+
+        return ifcopenshell.util.element
+    except ImportError:
+        return None
 
 
 def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
@@ -11,7 +38,9 @@ def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
     Extract IFC properties from a Blender object if it has IFC data.
     """
     try:
-        import bonsai.tool as tool
+        tool = get_ifc_tool()
+        if not tool:
+            return {}
 
         # Check if object has IFC data
         if not hasattr(blender_object, "BIMObjectProperties"):
@@ -53,9 +82,6 @@ def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
 
         return properties
 
-    except ImportError:
-        # Bonsai/ifcopenshell not available, silently return empty dict
-        return {}
     except Exception as e:
         # Other errors, log and return empty dict
         print(f"Error extracting IFC properties: {e}")
@@ -113,12 +139,14 @@ def _get_ifc_element_type_properties(element) -> Dict[str, Dict[str, Any]]:
     Extract properties from element type's property sets.
     """
     try:
-        import ifcopenshell.util.element
+        ifcopenshell_util_element = get_ifcopenshell_util_element()
+        if not ifcopenshell_util_element:
+            return {}
 
         properties = {}
 
         # Get relating type
-        relating_type = ifcopenshell.util.element.get_type(element)
+        relating_type = ifcopenshell_util_element.get_type(element)
         if not relating_type:
             return {}
 
@@ -145,10 +173,12 @@ def _get_element_type_attributes(element) -> Dict[str, Any]:
     Extract attributes from element type definition.
     """
     try:
-        import ifcopenshell.util.element
+        ifcopenshell_util_element = get_ifcopenshell_util_element()
+        if not ifcopenshell_util_element:
+            return {}
 
         # Get relating type
-        relating_type = ifcopenshell.util.element.get_type(element)
+        relating_type = ifcopenshell_util_element.get_type(element)
         if not relating_type:
             return {}
 
@@ -236,7 +266,9 @@ def validate_ifc_object(blender_object: Object) -> tuple[bool, str]:
     Validate that a Blender object is a valid IFC element.
     """
     try:
-        import bonsai.tool as tool
+        tool = get_ifc_tool()
+        if not tool:
+            return False, "Bonsai addon not available"
 
         if not blender_object:
             return False, "No object provided"
@@ -256,7 +288,5 @@ def validate_ifc_object(blender_object: Object) -> tuple[bool, str]:
 
         return True, "Valid IFC object"
 
-    except ImportError:
-        return False, "Bonsai addon not available"
     except Exception as e:
         return False, f"Validation error: {e}"

--- a/bpy_speckle/converter/to_speckle/ifc_properties.py
+++ b/bpy_speckle/converter/to_speckle/ifc_properties.py
@@ -1,3 +1,7 @@
+"""
+All IFC-related imports are wrapped in try-except blocks to ensure the code only runs when Bonsai/ifcopenshell is available.
+"""
+
 from typing import Dict, Any
 from bpy.types import Object
 
@@ -25,28 +29,29 @@ def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
         if not ifc_entity:
             return {}
 
-        # Initialize result dictionary
-        ifc_properties = {}
+        properties = {}
 
-        # Extract IFC attributes
-        ifc_properties["ifc_attributes"] = _extract_ifc_attributes(ifc_entity)
+        # extract element attributes
+        attributes = _get_attributes(ifc_entity)
+        if attributes:
+            properties["Attributes"] = attributes
 
-        # Extract property sets
-        ifc_properties["ifc_property_sets"] = _extract_property_sets(ifc_entity)
+        # extract element property sets
+        property_sets = _get_ifc_object_properties(ifc_entity)
+        if property_sets:
+            properties["Property Sets"] = property_sets
 
-        # Extract type information
-        ifc_properties["ifc_type_info"] = _extract_type_info(ifc_entity)
+        # extract element type property sets
+        type_property_sets = _get_ifc_element_type_properties(ifc_entity)
+        if type_property_sets:
+            properties["Element Type Property Sets"] = type_property_sets
 
-        # Extract spatial information
-        ifc_properties["ifc_spatial_info"] = _extract_spatial_info(ifc_entity)
+        # extract element type attributes
+        type_attributes = _get_element_type_attributes(ifc_entity)
+        if type_attributes:
+            properties["Element Type Attributes"] = type_attributes
 
-        # Extract material information
-        ifc_properties["ifc_materials"] = _extract_material_info(ifc_entity)
-
-        # Remove empty sections to keep output clean
-        ifc_properties = {k: v for k, v in ifc_properties.items() if v}
-
-        return ifc_properties
+        return properties
 
     except ImportError:
         # Bonsai/ifcopenshell not available, silently return empty dict
@@ -57,216 +62,172 @@ def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
         return {}
 
 
-def _extract_ifc_attributes(ifc_entity) -> Dict[str, Any]:
-    """Extract basic IFC attributes from an entity."""
+def _get_attributes(element) -> Dict[str, Any]:
+    """
+    Extract direct attributes from IFC element.
+    """
     try:
-        attributes = {}
-
-        # Get all attributes
-        entity_info = ifc_entity.get_info()
-
-        # Filter out None values and complex types
-        for attr_name, attr_value in entity_info.items():
-            if attr_value is not None and not hasattr(attr_value, "is_a"):
-                # Only include simple types that can be serialized
-                if isinstance(attr_value, (str, int, float, bool)):
-                    attributes[attr_name] = attr_value
-                elif isinstance(attr_value, (list, tuple)):
-                    # Handle simple lists
-                    if all(
-                        isinstance(item, (str, int, float, bool)) for item in attr_value
-                    ):
-                        attributes[attr_name] = list(attr_value)
-
-        return attributes
-
+        # Use scalar_only=True for performance as per documentation
+        return element.get_info(True, False, scalar_only=True)
     except Exception as e:
-        print(f"Error extracting IFC attributes: {e}")
+        print(f"Error extracting attributes: {e}")
         return {}
 
 
-def _extract_property_sets(ifc_entity) -> Dict[str, Dict[str, Any]]:
-    """Extract property sets from an IFC entity."""
+def _get_ifc_object_properties(element) -> Dict[str, Dict[str, Any]]:
+    """
+    Extract properties from element's direct property relationships.
+    """
     try:
-        import ifcopenshell.util.pset
+        properties = {}
 
-        # Get all property sets
-        psets = ifcopenshell.util.pset.get_psets(ifc_entity)
+        # Process IsDefinedBy relationships
+        if hasattr(element, "IsDefinedBy"):
+            for relationship in element.IsDefinedBy:
+                # Filter for IfcRelDefinesByProperties
+                if relationship.is_a("IfcRelDefinesByProperties"):
+                    relating_property_definition = (
+                        relationship.RelatingPropertyDefinition
+                    )
+                    # Filter for IfcPropertySet definitions
+                    if relating_property_definition.is_a("IfcPropertySet"):
+                        pset_name = relating_property_definition.Name
+                        if pset_name and hasattr(
+                            relating_property_definition, "HasProperties"
+                        ):
+                            pset_properties = _get_properties(
+                                relating_property_definition
+                            )
+                            if pset_properties:
+                                properties[pset_name] = pset_properties
 
-        # Filter out None values and ensure serializable types
-        filtered_psets = {}
-        for pset_name, properties in psets.items():
-            if properties:
-                filtered_props = {}
-                for prop_name, prop_value in properties.items():
-                    if prop_value is not None:
-                        if isinstance(prop_value, (str, int, float, bool)):
-                            filtered_props[prop_name] = prop_value
-                        elif isinstance(prop_value, (list, tuple)):
-                            if all(
-                                isinstance(item, (str, int, float, bool))
-                                for item in prop_value
-                            ):
-                                filtered_props[prop_name] = list(prop_value)
-
-                if filtered_props:
-                    filtered_psets[pset_name] = filtered_props
-
-        return filtered_psets
+        return properties
 
     except Exception as e:
-        print(f"Error extracting property sets: {e}")
+        print(f"Error extracting object properties: {e}")
         return {}
 
 
-def _extract_type_info(ifc_entity) -> Dict[str, Any]:
-    """Extract type information from an IFC entity."""
+def _get_ifc_element_type_properties(element) -> Dict[str, Dict[str, Any]]:
+    """
+    Extract properties from element type's property sets.
+    """
     try:
         import ifcopenshell.util.element
-        import ifcopenshell.util.pset
+
+        properties = {}
 
         # Get relating type
-        relating_type = ifcopenshell.util.element.get_type(ifc_entity)
-
+        relating_type = ifcopenshell.util.element.get_type(element)
         if not relating_type:
             return {}
 
-        type_info = {}
+        # Iterate through HasPropertySets relationship
+        if hasattr(relating_type, "HasPropertySets"):
+            for property_set in relating_type.HasPropertySets:
+                # Filter for IfcPropertySet types only
+                if property_set.is_a("IfcPropertySet"):
+                    pset_name = property_set.Name
+                    if pset_name and hasattr(property_set, "HasProperties"):
+                        pset_properties = _get_properties(property_set)
+                        if pset_properties:
+                            properties[pset_name] = pset_properties
 
-        # Basic type information
-        type_info["name"] = relating_type.Name
-        type_info["class"] = relating_type.is_a()
-        type_info["description"] = relating_type.Description
-
-        # Type properties
-        type_psets = ifcopenshell.util.pset.get_psets(relating_type)
-        if type_psets:
-            filtered_type_psets = {}
-            for pset_name, properties in type_psets.items():
-                if properties:
-                    filtered_props = {}
-                    for prop_name, prop_value in properties.items():
-                        if prop_value is not None:
-                            if isinstance(prop_value, (str, int, float, bool)):
-                                filtered_props[prop_name] = prop_value
-                            elif isinstance(prop_value, (list, tuple)):
-                                if all(
-                                    isinstance(item, (str, int, float, bool))
-                                    for item in prop_value
-                                ):
-                                    filtered_props[prop_name] = list(prop_value)
-
-                    if filtered_props:
-                        filtered_type_psets[pset_name] = filtered_props
-
-            if filtered_type_psets:
-                type_info["properties"] = filtered_type_psets
-
-        return type_info
+        return properties
 
     except Exception as e:
-        print(f"Error extracting type info: {e}")
+        print(f"Error extracting element type properties: {e}")
         return {}
 
 
-def _extract_spatial_info(ifc_entity) -> Dict[str, Any]:
-    """Extract spatial container and hierarchy information."""
+def _get_element_type_attributes(element) -> Dict[str, Any]:
+    """
+    Extract attributes from element type definition.
+    """
     try:
         import ifcopenshell.util.element
 
-        # Get spatial container
-        container = ifcopenshell.util.element.get_container(ifc_entity)
-
-        if not container:
+        # Get relating type
+        relating_type = ifcopenshell.util.element.get_type(element)
+        if not relating_type:
             return {}
 
-        spatial_info = {}
-
-        # Container information
-        spatial_info["container_name"] = container.Name
-        spatial_info["container_class"] = container.is_a()
-        spatial_info["container_description"] = container.Description
-
-        # Build spatial hierarchy
-        hierarchy = []
-        current = container
-
-        while current:
-            hierarchy.append(
-                {
-                    "name": current.Name,
-                    "class": current.is_a(),
-                    "description": current.Description,
-                }
-            )
-            current = ifcopenshell.util.element.get_container(current)
-
-        if hierarchy:
-            spatial_info["hierarchy"] = hierarchy
-
-        return spatial_info
+        # Extract attributes using scalar_only=True
+        return relating_type.get_info(True, False, scalar_only=True)
 
     except Exception as e:
-        print(f"Error extracting spatial info: {e}")
+        print(f"Error extracting element type attributes: {e}")
         return {}
 
 
-def _extract_material_info(ifc_entity) -> Dict[str, Any]:
-    """Extract material information from an IFC entity."""
+def _get_properties(properties_container) -> Dict[str, Any]:
+    """
+    core property value extraction function.
+
+    Handles 3 IFC property types:
+    - IfcPropertySingleValue: Single property values
+    - IfcPropertyListValue: List of property values
+    - IfcPropertyEnumeratedValue: Enumerated property values
+    """
     try:
-        import ifcopenshell.util.element
-        import ifcopenshell.util.pset
+        properties = {}
 
-        # Get material information
-        materials = ifcopenshell.util.element.get_materials(ifc_entity)
-
-        if not materials:
+        if not hasattr(properties_container, "HasProperties"):
             return {}
 
-        material_info = {}
+        for prop in properties_container.HasProperties:
+            prop_name = prop.Name
+            if not prop_name:
+                continue
 
-        for i, material in enumerate(materials):
-            material_data = {
-                "name": material.Name,
-                "description": getattr(material, "Description", None),
-                "category": getattr(material, "Category", None),
-            }
+            prop_value = None
 
-            # Get material properties
-            material_psets = ifcopenshell.util.pset.get_psets(material)
-            if material_psets:
-                filtered_material_psets = {}
-                for pset_name, properties in material_psets.items():
-                    if properties:
-                        filtered_props = {}
-                        for prop_name, prop_value in properties.items():
-                            if prop_value is not None:
-                                if isinstance(prop_value, (str, int, float, bool)):
-                                    filtered_props[prop_name] = prop_value
-                                elif isinstance(prop_value, (list, tuple)):
-                                    if all(
-                                        isinstance(item, (str, int, float, bool))
-                                        for item in prop_value
-                                    ):
-                                        filtered_props[prop_name] = list(prop_value)
+            # Handle IfcPropertySingleValue
+            if prop.is_a("IfcPropertySingleValue"):
+                if hasattr(prop, "NominalValue") and prop.NominalValue is not None:
+                    prop_value = prop.NominalValue
+                    # Unwrap wrappedValue if present
+                    if hasattr(prop_value, "wrappedValue"):
+                        prop_value = prop_value.wrappedValue
 
-                        if filtered_props:
-                            filtered_material_psets[pset_name] = filtered_props
+            # Handle IfcPropertyListValue
+            elif prop.is_a("IfcPropertyListValue"):
+                if hasattr(prop, "ListValues") and prop.ListValues:
+                    list_values = []
+                    for list_item in prop.ListValues:
+                        item_value = list_item
+                        # Unwrap wrappedValue if present
+                        if hasattr(item_value, "wrappedValue"):
+                            item_value = item_value.wrappedValue
+                        if item_value is not None:
+                            list_values.append(item_value)
+                    if list_values:
+                        prop_value = list_values
 
-                if filtered_material_psets:
-                    material_data["properties"] = filtered_material_psets
+            # Handle IfcPropertyEnumeratedValue
+            elif prop.is_a("IfcPropertyEnumeratedValue"):
+                if hasattr(prop, "EnumerationValues") and prop.EnumerationValues:
+                    enum_values = []
+                    for enum_item in prop.EnumerationValues:
+                        item_value = enum_item
+                        # Unwrap wrappedValue if present
+                        if hasattr(item_value, "wrappedValue"):
+                            item_value = item_value.wrappedValue
+                        if item_value is not None:
+                            enum_values.append(item_value)
+                    if enum_values:
+                        prop_value = (
+                            enum_values if len(enum_values) > 1 else enum_values[0]
+                        )
 
-            # Remove None values
-            material_data = {k: v for k, v in material_data.items() if v is not None}
+            # Add property if value was successfully extracted
+            if prop_value is not None:
+                properties[prop_name] = prop_value
 
-            if material_data:
-                material_key = f"material_{i}" if len(materials) > 1 else "material"
-                material_info[material_key] = material_data
-
-        return material_info
+        return properties
 
     except Exception as e:
-        print(f"Error extracting material info: {e}")
+        print(f"Error extracting properties from container: {e}")
         return {}
 
 

--- a/bpy_speckle/converter/to_speckle/ifc_properties.py
+++ b/bpy_speckle/converter/to_speckle/ifc_properties.py
@@ -3,7 +3,7 @@ All IFC-related imports are wrapped in try-except blocks to ensure the code only
 """
 
 from functools import lru_cache
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 from bpy.types import Object
 
 
@@ -261,7 +261,7 @@ def _get_properties(properties_container) -> Dict[str, Any]:
         return {}
 
 
-def validate_ifc_object(blender_object: Object) -> tuple[bool, str]:
+def validate_ifc_object(blender_object: Object) -> Tuple[bool, str]:
     """
     Validate that a Blender object is a valid IFC element.
     """

--- a/bpy_speckle/converter/to_speckle/ifc_properties.py
+++ b/bpy_speckle/converter/to_speckle/ifc_properties.py
@@ -1,0 +1,301 @@
+from typing import Dict, Any
+from bpy.types import Object
+
+
+def extract_ifc_properties(blender_object: Object) -> Dict[str, Any]:
+    """
+    Extract IFC properties from a Blender object if it has IFC data.
+    """
+    try:
+        import bonsai.tool as tool
+
+        # Check if object has IFC data
+        if not hasattr(blender_object, "BIMObjectProperties"):
+            return {}
+
+        if not blender_object.BIMObjectProperties.ifc_definition_id:
+            return {}
+
+        # Check if IFC file is loaded
+        if not tool.Ifc.get():
+            return {}
+
+        # Get IFC entity
+        ifc_entity = tool.Ifc.get_entity(blender_object)
+        if not ifc_entity:
+            return {}
+
+        # Initialize result dictionary
+        ifc_properties = {}
+
+        # Extract IFC attributes
+        ifc_properties["ifc_attributes"] = _extract_ifc_attributes(ifc_entity)
+
+        # Extract property sets
+        ifc_properties["ifc_property_sets"] = _extract_property_sets(ifc_entity)
+
+        # Extract type information
+        ifc_properties["ifc_type_info"] = _extract_type_info(ifc_entity)
+
+        # Extract spatial information
+        ifc_properties["ifc_spatial_info"] = _extract_spatial_info(ifc_entity)
+
+        # Extract material information
+        ifc_properties["ifc_materials"] = _extract_material_info(ifc_entity)
+
+        # Remove empty sections to keep output clean
+        ifc_properties = {k: v for k, v in ifc_properties.items() if v}
+
+        return ifc_properties
+
+    except ImportError:
+        # Bonsai/ifcopenshell not available, silently return empty dict
+        return {}
+    except Exception as e:
+        # Other errors, log and return empty dict
+        print(f"Error extracting IFC properties: {e}")
+        return {}
+
+
+def _extract_ifc_attributes(ifc_entity) -> Dict[str, Any]:
+    """Extract basic IFC attributes from an entity."""
+    try:
+        attributes = {}
+
+        # Get all attributes
+        entity_info = ifc_entity.get_info()
+
+        # Filter out None values and complex types
+        for attr_name, attr_value in entity_info.items():
+            if attr_value is not None and not hasattr(attr_value, "is_a"):
+                # Only include simple types that can be serialized
+                if isinstance(attr_value, (str, int, float, bool)):
+                    attributes[attr_name] = attr_value
+                elif isinstance(attr_value, (list, tuple)):
+                    # Handle simple lists
+                    if all(
+                        isinstance(item, (str, int, float, bool)) for item in attr_value
+                    ):
+                        attributes[attr_name] = list(attr_value)
+
+        return attributes
+
+    except Exception as e:
+        print(f"Error extracting IFC attributes: {e}")
+        return {}
+
+
+def _extract_property_sets(ifc_entity) -> Dict[str, Dict[str, Any]]:
+    """Extract property sets from an IFC entity."""
+    try:
+        import ifcopenshell.util.pset
+
+        # Get all property sets
+        psets = ifcopenshell.util.pset.get_psets(ifc_entity)
+
+        # Filter out None values and ensure serializable types
+        filtered_psets = {}
+        for pset_name, properties in psets.items():
+            if properties:
+                filtered_props = {}
+                for prop_name, prop_value in properties.items():
+                    if prop_value is not None:
+                        if isinstance(prop_value, (str, int, float, bool)):
+                            filtered_props[prop_name] = prop_value
+                        elif isinstance(prop_value, (list, tuple)):
+                            if all(
+                                isinstance(item, (str, int, float, bool))
+                                for item in prop_value
+                            ):
+                                filtered_props[prop_name] = list(prop_value)
+
+                if filtered_props:
+                    filtered_psets[pset_name] = filtered_props
+
+        return filtered_psets
+
+    except Exception as e:
+        print(f"Error extracting property sets: {e}")
+        return {}
+
+
+def _extract_type_info(ifc_entity) -> Dict[str, Any]:
+    """Extract type information from an IFC entity."""
+    try:
+        import ifcopenshell.util.element
+        import ifcopenshell.util.pset
+
+        # Get relating type
+        relating_type = ifcopenshell.util.element.get_type(ifc_entity)
+
+        if not relating_type:
+            return {}
+
+        type_info = {}
+
+        # Basic type information
+        type_info["name"] = relating_type.Name
+        type_info["class"] = relating_type.is_a()
+        type_info["description"] = relating_type.Description
+
+        # Type properties
+        type_psets = ifcopenshell.util.pset.get_psets(relating_type)
+        if type_psets:
+            filtered_type_psets = {}
+            for pset_name, properties in type_psets.items():
+                if properties:
+                    filtered_props = {}
+                    for prop_name, prop_value in properties.items():
+                        if prop_value is not None:
+                            if isinstance(prop_value, (str, int, float, bool)):
+                                filtered_props[prop_name] = prop_value
+                            elif isinstance(prop_value, (list, tuple)):
+                                if all(
+                                    isinstance(item, (str, int, float, bool))
+                                    for item in prop_value
+                                ):
+                                    filtered_props[prop_name] = list(prop_value)
+
+                    if filtered_props:
+                        filtered_type_psets[pset_name] = filtered_props
+
+            if filtered_type_psets:
+                type_info["properties"] = filtered_type_psets
+
+        return type_info
+
+    except Exception as e:
+        print(f"Error extracting type info: {e}")
+        return {}
+
+
+def _extract_spatial_info(ifc_entity) -> Dict[str, Any]:
+    """Extract spatial container and hierarchy information."""
+    try:
+        import ifcopenshell.util.element
+
+        # Get spatial container
+        container = ifcopenshell.util.element.get_container(ifc_entity)
+
+        if not container:
+            return {}
+
+        spatial_info = {}
+
+        # Container information
+        spatial_info["container_name"] = container.Name
+        spatial_info["container_class"] = container.is_a()
+        spatial_info["container_description"] = container.Description
+
+        # Build spatial hierarchy
+        hierarchy = []
+        current = container
+
+        while current:
+            hierarchy.append(
+                {
+                    "name": current.Name,
+                    "class": current.is_a(),
+                    "description": current.Description,
+                }
+            )
+            current = ifcopenshell.util.element.get_container(current)
+
+        if hierarchy:
+            spatial_info["hierarchy"] = hierarchy
+
+        return spatial_info
+
+    except Exception as e:
+        print(f"Error extracting spatial info: {e}")
+        return {}
+
+
+def _extract_material_info(ifc_entity) -> Dict[str, Any]:
+    """Extract material information from an IFC entity."""
+    try:
+        import ifcopenshell.util.element
+        import ifcopenshell.util.pset
+
+        # Get material information
+        materials = ifcopenshell.util.element.get_materials(ifc_entity)
+
+        if not materials:
+            return {}
+
+        material_info = {}
+
+        for i, material in enumerate(materials):
+            material_data = {
+                "name": material.Name,
+                "description": getattr(material, "Description", None),
+                "category": getattr(material, "Category", None),
+            }
+
+            # Get material properties
+            material_psets = ifcopenshell.util.pset.get_psets(material)
+            if material_psets:
+                filtered_material_psets = {}
+                for pset_name, properties in material_psets.items():
+                    if properties:
+                        filtered_props = {}
+                        for prop_name, prop_value in properties.items():
+                            if prop_value is not None:
+                                if isinstance(prop_value, (str, int, float, bool)):
+                                    filtered_props[prop_name] = prop_value
+                                elif isinstance(prop_value, (list, tuple)):
+                                    if all(
+                                        isinstance(item, (str, int, float, bool))
+                                        for item in prop_value
+                                    ):
+                                        filtered_props[prop_name] = list(prop_value)
+
+                        if filtered_props:
+                            filtered_material_psets[pset_name] = filtered_props
+
+                if filtered_material_psets:
+                    material_data["properties"] = filtered_material_psets
+
+            # Remove None values
+            material_data = {k: v for k, v in material_data.items() if v is not None}
+
+            if material_data:
+                material_key = f"material_{i}" if len(materials) > 1 else "material"
+                material_info[material_key] = material_data
+
+        return material_info
+
+    except Exception as e:
+        print(f"Error extracting material info: {e}")
+        return {}
+
+
+def validate_ifc_object(blender_object: Object) -> tuple[bool, str]:
+    """
+    Validate that a Blender object is a valid IFC element.
+    """
+    try:
+        import bonsai.tool as tool
+
+        if not blender_object:
+            return False, "No object provided"
+
+        if not hasattr(blender_object, "BIMObjectProperties"):
+            return False, "Object has no BIM properties"
+
+        if not blender_object.BIMObjectProperties.ifc_definition_id:
+            return False, "Object has no IFC definition ID"
+
+        if not tool.Ifc.get():
+            return False, "No IFC file loaded"
+
+        ifc_entity = tool.Ifc.get_entity(blender_object)
+        if not ifc_entity:
+            return False, "Cannot find IFC entity"
+
+        return True, "Valid IFC object"
+
+    except ImportError:
+        return False, "Bonsai addon not available"
+    except Exception as e:
+        return False, f"Validation error: {e}"

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -8,7 +8,7 @@ from mathutils import Vector as MVector
 
 from specklepy.objects.base import Base
 from specklepy.objects.geometry.mesh import Mesh
-from .utils import get_submesh_id
+from .utils import get_submesh_id, extract_custom_properties
 
 
 def mesh_to_speckle(
@@ -106,6 +106,11 @@ def mesh_to_speckle_meshes(
             speckle_mesh.area = mesh_area
 
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
+
+        # Add custom properties from the mesh data
+        mesh_properties = extract_custom_properties(data)
+        if mesh_properties:
+            speckle_mesh.properties = mesh_properties
 
         submeshes.append(speckle_mesh)
 

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -12,7 +12,6 @@ from .utils import (
     get_submesh_id,
     apply_cached_properties,
     extract_all_properties,
-    extract_custom_properties,
 )
 
 
@@ -47,12 +46,9 @@ def mesh_to_speckle_meshes(
 
     submeshes = []
 
-    # Extract properties from both the object (including IFC) and mesh data
+    # Extract properties from the object (including IFC properties)
+    # Note: IFC properties belong to the object (building element), not mesh geometry
     object_properties = extract_all_properties(blender_object)
-    mesh_properties = extract_custom_properties(data)
-
-    # Merge properties - object properties (including IFC) take precedence
-    combined_properties = {**mesh_properties, **object_properties}
 
     # sort material indices to ensure consistent ordering
     for material_index in sorted(submesh_data.keys()):
@@ -119,8 +115,8 @@ def mesh_to_speckle_meshes(
 
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
 
-        # Add combined properties (mesh data + object properties including IFC)
-        apply_cached_properties(speckle_mesh, combined_properties)
+        # Add object properties (including IFC properties) to submesh
+        apply_cached_properties(speckle_mesh, object_properties)
 
         submeshes.append(speckle_mesh)
 

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -8,7 +8,12 @@ from mathutils import Vector as MVector
 
 from specklepy.objects.base import Base
 from specklepy.objects.geometry.mesh import Mesh
-from .utils import get_submesh_id, apply_cached_properties, extract_custom_properties
+from .utils import (
+    get_submesh_id,
+    apply_cached_properties,
+    extract_all_properties,
+    extract_custom_properties,
+)
 
 
 def mesh_to_speckle(
@@ -42,8 +47,12 @@ def mesh_to_speckle_meshes(
 
     submeshes = []
 
-    # Extract custom properties once for all submeshes (shared mesh data)
+    # Extract properties from both the object (including IFC) and mesh data
+    object_properties = extract_all_properties(blender_object)
     mesh_properties = extract_custom_properties(data)
+
+    # Merge properties - object properties (including IFC) take precedence
+    combined_properties = {**mesh_properties, **object_properties}
 
     # sort material indices to ensure consistent ordering
     for material_index in sorted(submesh_data.keys()):
@@ -110,8 +119,8 @@ def mesh_to_speckle_meshes(
 
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
 
-        # Add custom properties from the mesh data
-        apply_cached_properties(speckle_mesh, mesh_properties)
+        # Add combined properties (mesh data + object properties including IFC)
+        apply_cached_properties(speckle_mesh, combined_properties)
 
         submeshes.append(speckle_mesh)
 

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -42,6 +42,9 @@ def mesh_to_speckle_meshes(
 
     submeshes = []
 
+    # Extract custom properties once for all submeshes (shared mesh data)
+    mesh_properties = extract_custom_properties(data)
+
     # sort material indices to ensure consistent ordering
     for material_index in sorted(submesh_data.keys()):
         mesh_area = 0
@@ -108,7 +111,6 @@ def mesh_to_speckle_meshes(
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
 
         # Add custom properties from the mesh data
-        mesh_properties = extract_custom_properties(data)
         if mesh_properties:
             speckle_mesh.properties = mesh_properties
 

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -11,7 +11,7 @@ from specklepy.objects.geometry.mesh import Mesh
 from .utils import (
     get_submesh_id,
     apply_cached_properties,
-    extract_all_properties,
+    extract_custom_properties,
 )
 
 
@@ -46,9 +46,7 @@ def mesh_to_speckle_meshes(
 
     submeshes = []
 
-    # Extract properties from the object (including IFC properties)
-    # Note: IFC properties belong to the object (building element), not mesh geometry
-    object_properties = extract_all_properties(blender_object)
+    mesh_properties = extract_custom_properties(data)
 
     # sort material indices to ensure consistent ordering
     for material_index in sorted(submesh_data.keys()):
@@ -115,8 +113,8 @@ def mesh_to_speckle_meshes(
 
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
 
-        # Add object properties (including IFC properties) to submesh
-        apply_cached_properties(speckle_mesh, object_properties)
+        if mesh_properties:
+            apply_cached_properties(speckle_mesh, mesh_properties)
 
         submeshes.append(speckle_mesh)
 

--- a/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/mesh_to_speckle.py
@@ -8,7 +8,7 @@ from mathutils import Vector as MVector
 
 from specklepy.objects.base import Base
 from specklepy.objects.geometry.mesh import Mesh
-from .utils import get_submesh_id, extract_custom_properties
+from .utils import get_submesh_id, apply_cached_properties, extract_custom_properties
 
 
 def mesh_to_speckle(
@@ -111,8 +111,7 @@ def mesh_to_speckle_meshes(
         speckle_mesh.applicationId = get_submesh_id(blender_object, material_index)
 
         # Add custom properties from the mesh data
-        if mesh_properties:
-            speckle_mesh.properties = mesh_properties
+        apply_cached_properties(speckle_mesh, mesh_properties)
 
         submeshes.append(speckle_mesh)
 

--- a/bpy_speckle/converter/to_speckle/to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/to_speckle.py
@@ -3,7 +3,7 @@ from typing import Optional
 from specklepy.objects.data_objects import BlenderObject
 from .curve_to_speckle import curve_to_speckle
 from .mesh_to_speckle import mesh_to_speckle_meshes
-from .utils import get_object_id, get_curve_element_id, extract_custom_properties
+from .utils import get_object_id, get_curve_element_id, extract_all_properties
 
 
 def convert_to_speckle(
@@ -13,7 +13,7 @@ def convert_to_speckle(
     apply_modifiers: bool = True,
 ) -> Optional[BlenderObject]:
     display_value = []
-    properties = extract_custom_properties(blender_object)
+    properties = extract_all_properties(blender_object)
 
     if blender_object.type == "CURVE":
         # handle curve modifiers apply_modifiers is True

--- a/bpy_speckle/converter/to_speckle/to_speckle.py
+++ b/bpy_speckle/converter/to_speckle/to_speckle.py
@@ -3,7 +3,7 @@ from typing import Optional
 from specklepy.objects.data_objects import BlenderObject
 from .curve_to_speckle import curve_to_speckle
 from .mesh_to_speckle import mesh_to_speckle_meshes
-from .utils import get_object_id, get_curve_element_id
+from .utils import get_object_id, get_curve_element_id, extract_custom_properties
 
 
 def convert_to_speckle(
@@ -13,18 +13,18 @@ def convert_to_speckle(
     apply_modifiers: bool = True,
 ) -> Optional[BlenderObject]:
     display_value = []
-    properties = {}
+    properties = extract_custom_properties(blender_object)
 
     if blender_object.type == "CURVE":
         # handle curve modifiers apply_modifiers is True
         if apply_modifiers and blender_object.modifiers:
             import bpy
-            
+
             # Convert curve with modifiers to mesh
             depsgraph = bpy.context.evaluated_depsgraph_get()
             evaluated_obj = blender_object.evaluated_get(depsgraph)
             evaluated_mesh = evaluated_obj.to_mesh()
-            
+
             if evaluated_mesh:
                 meshes = mesh_to_speckle_meshes(
                     blender_object, evaluated_mesh, scale_factor, units
@@ -50,20 +50,22 @@ def convert_to_speckle(
         mesh_data = blender_object.data
         if apply_modifiers and blender_object.modifiers:
             import bpy
-            
+
             # use evaluated object to get mesh with modifiers applied
             depsgraph = bpy.context.evaluated_depsgraph_get()
             evaluated_obj = blender_object.evaluated_get(depsgraph)
             evaluated_mesh = evaluated_obj.to_mesh()
             mesh_data = evaluated_mesh
-        
-        meshes = mesh_to_speckle_meshes(
-            blender_object, mesh_data, scale_factor, units
-        )
-        
-        if apply_modifiers and blender_object.modifiers and mesh_data != blender_object.data:
+
+        meshes = mesh_to_speckle_meshes(blender_object, mesh_data, scale_factor, units)
+
+        if (
+            apply_modifiers
+            and blender_object.modifiers
+            and mesh_data != blender_object.data
+        ):
             blender_object.to_mesh_clear()
-        
+
         if meshes:
             display_value = meshes
 

--- a/bpy_speckle/converter/to_speckle/utils.py
+++ b/bpy_speckle/converter/to_speckle/utils.py
@@ -288,6 +288,23 @@ def extract_custom_properties(blender_id: ID) -> dict:
     return properties
 
 
+def extract_all_properties(blender_object: Object) -> dict:
+    """
+    Extract all properties from a Blender object including custom properties and IFC properties.
+    """
+    from .ifc_properties import extract_ifc_properties
+
+    # Start with Blender custom properties
+    properties = extract_custom_properties(blender_object)
+
+    # Add IFC properties if available
+    ifc_properties = extract_ifc_properties(blender_object)
+    if ifc_properties:
+        properties.update(ifc_properties)
+
+    return properties
+
+
 def apply_custom_properties(speckle_obj, blender_data: ID) -> None:
     """Apply custom properties to a Speckle object if they exist."""
     properties = extract_custom_properties(blender_data)
@@ -295,7 +312,14 @@ def apply_custom_properties(speckle_obj, blender_data: ID) -> None:
         speckle_obj.properties = properties
 
 
-def apply_cached_properties(speckle_obj, properties: dict ) -> None:
-    """Apply pre-extracted custom properties to a Speckle object if they exist."""
+def apply_all_properties(speckle_obj, blender_object: Object) -> None:
+    """Apply all properties (custom and IFC) to a Speckle object if they exist."""
+    properties = extract_all_properties(blender_object)
+    if properties:
+        speckle_obj.properties = properties
+
+
+def apply_cached_properties(speckle_obj, properties: dict) -> None:
+    """Apply pre-extracted properties to a Speckle object if they exist."""
     if properties:
         speckle_obj.properties = properties

--- a/bpy_speckle/converter/to_speckle/utils.py
+++ b/bpy_speckle/converter/to_speckle/utils.py
@@ -294,15 +294,22 @@ def extract_all_properties(blender_object: Object) -> dict:
     """
     from .ifc_properties import extract_ifc_properties
 
-    # Start with Blender custom properties
-    properties = extract_custom_properties(blender_object)
+    # Extract Blender custom properties
+    custom_properties = extract_custom_properties(blender_object)
 
-    # Add IFC properties if available
+    # Extract IFC properties if available
     ifc_properties = extract_ifc_properties(blender_object)
-    if ifc_properties:
-        properties.update(ifc_properties)
 
-    return properties
+    # Organize properties under two main sections
+    organized_properties = {}
+
+    if custom_properties:
+        organized_properties["Custom Properties"] = custom_properties
+
+    if ifc_properties:
+        organized_properties["IFC Properties"] = ifc_properties
+
+    return organized_properties
 
 
 def apply_custom_properties(speckle_obj, blender_data: ID) -> None:

--- a/bpy_speckle/converter/to_speckle/utils.py
+++ b/bpy_speckle/converter/to_speckle/utils.py
@@ -240,3 +240,49 @@ def get_curve_element_id(blender_object: Object, curve_index: int = 0) -> str:
 
 def get_object_id(blender_object: Object) -> str:
     return get_unique_id(blender_object)
+
+
+def extract_custom_properties(blender_id: ID) -> dict:
+    """
+    Extract custom user-defined properties from a Blender ID datablock.
+    """
+    properties = {}
+
+    # Get all custom property keys
+    for key in blender_id.keys():
+        # Skip system properties that start with underscore
+        if key.startswith("_"):
+            continue
+
+        try:
+            value = blender_id[key]
+
+            # Handle basic data types that Speckle can handle
+            if isinstance(value, (str, int, float, bool)):
+                properties[key] = value
+            elif isinstance(value, (list, tuple)):
+                # Handle arrays of basic types
+                if all(isinstance(item, (str, int, float, bool)) for item in value):
+                    properties[key] = list(value)
+            elif type(value).__name__ == "IDPropertyArray":
+                # Handle Blender IDPropertyArray types (BoolArray, IntArray, FloatArray)
+                try:
+                    # Convert to list using to_list() method if available, otherwise use list()
+                    if hasattr(value, "to_list"):
+                        array_list = value.to_list()
+                    else:
+                        array_list = list(value)
+
+                    # Verify all items are basic types
+                    if all(
+                        isinstance(item, (str, int, float, bool)) for item in array_list
+                    ):
+                        properties[key] = array_list
+                except (TypeError, ValueError):
+                    # Skip arrays that can't be converted
+                    continue
+        except (KeyError, TypeError):
+            # Skip properties that can't be accessed or have unsupported types
+            continue
+
+    return properties

--- a/bpy_speckle/converter/to_speckle/utils.py
+++ b/bpy_speckle/converter/to_speckle/utils.py
@@ -286,3 +286,16 @@ def extract_custom_properties(blender_id: ID) -> dict:
             continue
 
     return properties
+
+
+def apply_custom_properties(speckle_obj, blender_data: ID) -> None:
+    """Apply custom properties to a Speckle object if they exist."""
+    properties = extract_custom_properties(blender_data)
+    if properties:
+        speckle_obj.properties = properties
+
+
+def apply_cached_properties(speckle_obj, properties: dict ) -> None:
+    """Apply pre-extracted custom properties to a Speckle object if they exist."""
+    if properties:
+        speckle_obj.properties = properties


### PR DESCRIPTION
# DO NOT MERGE BEFORE #294 

This PR adds support for publishing IFC properties from Blender objects imported by **[Bonsai BIM](https://bonsaibim.org/)** addon.

- All IFC related imports are wrapped in try-except blocks to make sure code **only runs when Bonsai BIM is available.** When it's not installed, converter extracts only custom properties.
- **Uses the same property structure as our new IFC importer** (cc @JR-Morgan ) -> _Attributes, Property Sets, Element Type Property Sets, Element Type Attributes_

<img width="1912" height="1237" alt="Screenshot 2025-07-18 at 10 55 35" src="https://github.com/user-attachments/assets/7015e40f-5e41-4661-8563-1e14196cf706" />

<img width="1912" height="1237" alt="Screenshot 2025-07-18 at 10 55 51" src="https://github.com/user-attachments/assets/8626a7dc-8d78-434a-b038-bd8bf99b4ecf" />

