### PR TITLE
Update bl_info

### DIFF
--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -21,14 +21,14 @@ from .installer import ensure_dependencies
 ensure_dependencies(f"Blender {bpy.app.version[0]}.{bpy.app.version[1]}")
 
 bl_info = {
-    "name": "Speckle Blender ",
-    "author": "Speckle Systems",
+    "name": "Speckle Connector",
+    "author": "Speckle",
     "version": (3, 999, 999),
     "blender": (4, 2, 0),
     "location": "3d viewport toolbar (N), under the Speckle tab.",
-    "description": "The Speckle Connector using specklepy 3.x!",
-    "warning": "This add-on is WIP and should be used with caution",
-    "wiki_url": "https://github.com/specklesystems/speckle-blender",
+    "description": """Publish and load models from/to other AEC apps to boost design coordination workflows. Speckle has connectors for: 
+    Revit, Archicad, Rhino, Grasshopper, Tekla, Navisworks, AutoCAD, Civil3D, ETABS and Power BI.""",
+    "wiki_url": "https://speckle.systems/connectors/blender",
     "category": "Scene",
 }
 

--- a/bpy_speckle/__init__.py
+++ b/bpy_speckle/__init__.py
@@ -26,8 +26,7 @@ bl_info = {
     "version": (3, 999, 999),
     "blender": (4, 2, 0),
     "location": "3d viewport toolbar (N), under the Speckle tab.",
-    "description": """Publish and load models from/to other AEC apps to boost design coordination workflows. Speckle has connectors for: 
-    Revit, Archicad, Rhino, Grasshopper, Tekla, Navisworks, AutoCAD, Civil3D, ETABS and Power BI.""",
+    "description": "Publish models to and load models from other AEC apps.",
     "wiki_url": "https://speckle.systems/connectors/blender",
     "category": "Scene",
 }

--- a/bpy_speckle/blender_manifest.toml
+++ b/bpy_speckle/blender_manifest.toml
@@ -11,7 +11,7 @@ maintainer = "Speckle"
 type = "add-on"
 
 # Optional link to documentation, support, source files, etc
-website = "https://app.speckle.systems/connectors"
+website = "https://speckle.systems/connectors/blender"
 
 # Optional list defined by Blender and server, see:
 # https://docs.blender.org/manual/en/dev/advanced/extensions/tags.html
@@ -24,13 +24,9 @@ blender_version_min = "4.2.0"
 
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
 # https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
-license = [
-  "SPDX:Apache-2.0",
-]
+license = ["SPDX:Apache-2.0"]
 # Optional: required by some licenses.
-copyright = [
-  "2022-2025 AEC SYSTEMS LTD",
-]
+copyright = ["2022-2025 AEC SYSTEMS LTD"]
 
 # Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
 # platforms = ["windows-x64", "macos-arm64", "linux-x64"]
@@ -67,8 +63,4 @@ clipboard = "Copy and paste URLs and Names (UI)"
 # Optional: build settings.
 # https://docs.blender.org/manual/en/dev/advanced/extensions/command_line_arguments.html#command-line-args-extension-build
 [build]
-paths_exclude_pattern = [
-  "__pycache__/",
-  "/.vscode",
-  "*.code-workspace",
-]
+paths_exclude_pattern = ["__pycache__/", "/.vscode", "*.code-workspace"]


### PR DESCRIPTION
This PR updates bl_info. It also removes the warning that's been there for a while.

Before
<img width="493" alt="image" src="https://github.com/user-attachments/assets/619a9f7c-2045-4468-a66c-1aafad2356cf" />


After
<img width="493" alt="image" src="https://github.com/user-attachments/assets/b21e75d8-9bef-4f68-9bde-6e8c4b14fed5" />

Changes are pretty minimal and it's safe to merge unless there is an objection to the copy.