### PR TITLE
null check on active workspace

### DIFF
--- a/bpy_speckle/connector/ui/account_selection_dialog.py
+++ b/bpy_speckle/connector/ui/account_selection_dialog.py
@@ -123,7 +123,11 @@ def update_workspaces_list(context: Context) -> None:
         workspace: speckle_workspace = wm.speckle_workspaces.add()
         workspace.id = id
         workspace.name = name
-    wm.selected_workspace.id = get_active_workspace(wm.selected_account_id)["id"]
+    active_workspace = get_active_workspace(wm.selected_account_id)
+    if active_workspace:
+        wm.selected_workspace.id = active_workspace["id"]
+    else:
+        wm.selected_workspace.id = "personal"
     print("Updated Workspaces List!")
 
 

--- a/bpy_speckle/connector/ui/project_selection_dialog.py
+++ b/bpy_speckle/connector/ui/project_selection_dialog.py
@@ -120,10 +120,13 @@ class SPECKLE_OT_project_selection_dialog(bpy.types.Operator):
         if wm.selected_account_id == "":
             wm.selected_account_id = get_default_account_id()
 
-        wm.selected_workspace.id = get_active_workspace(wm.selected_account_id)["id"]
-        wm.selected_workspace.name = get_active_workspace(wm.selected_account_id)[
-            "name"
-        ]
+        active_workspace = get_active_workspace(wm.selected_account_id)
+        if active_workspace:
+            wm.selected_workspace.id = active_workspace["id"]
+            wm.selected_workspace.name = active_workspace["name"]
+        else:
+            wm.selected_workspace.id = "personal"
+            wm.selected_workspace.name = "Personal Projects"
 
         # Fetch projects from server
         projects: List[Tuple[str, str, str, str, bool]] = get_projects_for_account(


### PR DESCRIPTION
<img width="1225" height="359" alt="image" src="https://github.com/user-attachments/assets/7cca65bb-d5c8-46c1-a905-ea15a7661176" />
Adds null check for get_active_workspace. Handles the scenario where are there are no accounts added and hits get active workspace exception.