### PR TITLE
feat: display value proxy handler

### DIFF
--- a/bpy_speckle/connector/operations/load_operation.py
+++ b/bpy_speckle/connector/operations/load_operation.py
@@ -10,7 +10,11 @@ from specklepy.core.api import host_applications
 
 from ..utils.get_ascendants import get_ascendants
 from ..utils.account_manager import _client_cache
-from ...converter.utils import find_object_by_id, get_project_workspace_id
+from ...converter.utils import (
+    find_object_by_id,
+    get_project_workspace_id,
+    build_object_id_map,
+)
 from ...converter.to_native import (
     convert_to_native,
     render_material_proxy_to_native,
@@ -78,11 +82,17 @@ def load_operation(
             },
         )
 
+    # Build object ID map once
+    object_id_map = build_object_id_map(version_data)
+
     # Create material mapping first
     material_mapping = render_material_proxy_to_native(version_data)
 
     definition_collections, definition_objects = instance_definition_proxy_to_native(
-        version_data, material_mapping, instance_loading_mode=instance_loading_mode
+        version_data,
+        material_mapping,
+        instance_loading_mode=instance_loading_mode,
+        object_id_map=object_id_map,
     )
 
     definitions_root_collection = None
@@ -96,7 +106,8 @@ def load_operation(
     for definition in find_instance_definitions(version_data).values():
         definition_object_ids.update(definition.objects)
         for obj_id in definition.objects:
-            found_obj = find_object_by_id(version_data, obj_id)
+            # Use ID map
+            found_obj = object_id_map.get(obj_id)
             if found_obj:
                 if hasattr(found_obj, "id"):
                     definition_object_ids.add(found_obj.id)

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -348,18 +348,16 @@ def _members_to_native(
     # Check if the original object is a DataObject
     is_data_object = isinstance(speckle_object, DataObject)
 
-    # Process InstanceProxy objects first with proper definition collections
+    # Process InstanceProxy objects - do not add to children list as they are already
     for item in instance_proxies:
         try:
-            blender_object = convert_to_native(
+            convert_to_native(
                 item,
                 material_mapping,
                 definition_collections=definition_collections,
                 root_collection=root_collection,
                 instance_loading_mode="LINKED_DUPLICATES",  # always use Linked Duplicates for displayValue proxies
             )
-            if blender_object:
-                children.append(blender_object)
         except Exception as ex:
             print(f"Failed to convert instance proxy in display value {item}: {ex}")
 
@@ -1428,7 +1426,8 @@ def instance_proxy_to_linked_duplicates(
         print(f"Definition collection not found for instance {speckle_instance.id}")
         return None
 
-    unit_scale = proxy_scale(speckle_instance)
+    # Use the scale from the parent context
+    unit_scale = scale
 
     # convert transformation matrix
     matrix = mathutils.Matrix(
@@ -1463,7 +1462,6 @@ def instance_proxy_to_linked_duplicates(
     location, rotation, scale_vector = matrix.decompose()
     location = location * unit_scale
 
-    # create transformation matrix
     final_matrix = (
         mathutils.Matrix.Translation(location)
         @ rotation.to_matrix().to_4x4()
@@ -1475,10 +1473,8 @@ def instance_proxy_to_linked_duplicates(
     parent_empty.empty_display_type = "PLAIN_AXES"
     parent_empty.empty_display_size = 0.1
 
-    parent_empty.matrix_world = final_matrix
-
-    # link parent to root collection
     root_collection.objects.link(parent_empty)
+    parent_empty.matrix_world = final_matrix
 
     parent_empty["speckle_id"] = speckle_instance.id
     parent_empty["speckle_type"] = speckle_instance.speckle_type
@@ -1488,15 +1484,14 @@ def instance_proxy_to_linked_duplicates(
 
     duplicated_objects = []
     for obj in definition_collection.objects:
-        # create a copy of the object with linked data
         duplicate_obj = obj.copy()
-
         duplicate_obj.name = f"{obj.name}_{speckle_instance.id[:8]}"
 
         root_collection.objects.link(duplicate_obj)
 
-        # apply the instance transformation directly to each object
-        duplicate_obj.matrix_world = final_matrix @ obj.matrix_world
+        duplicate_obj.parent = parent_empty
+        duplicate_obj.matrix_parent_inverse.identity()
+        duplicate_obj.matrix_basis = obj.matrix_world
 
         duplicated_objects.append(duplicate_obj)
 
@@ -1516,7 +1511,8 @@ def instance_proxy_to_native(
         print(f"Definition collection not found for instance {speckle_instance.id}")
         return None
 
-    unit_scale = proxy_scale(speckle_instance)
+    # Use the scale from the parent context
+    unit_scale = scale
 
     # convert transformation matrix
     matrix = mathutils.Matrix(
@@ -1549,10 +1545,7 @@ def instance_proxy_to_native(
     )
 
     location, rotation, scale_vector = matrix.decompose()
-
     location = location * unit_scale
-
-    # Create collection instance directly
     instance_name = f"Instance_{speckle_instance.id}"
     instance_obj = bpy.data.objects.new(instance_name, None)
     instance_obj.instance_type = "COLLECTION"

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -159,7 +159,14 @@ def convert_to_native(
     else:
         # Fallback to display value if direct conversion not supported
         mesh, children = display_value_to_native(
-            speckle_object, object_name, data_block_name, scale, material_mapping
+            speckle_object,
+            object_name,
+            data_block_name,
+            scale,
+            material_mapping,
+            definition_collections,
+            root_collection,
+            instance_loading_mode,
         )
         if mesh:
             # Create a mesh object with the object_name (simple name) and mesh data
@@ -176,7 +183,11 @@ def convert_to_native(
             # Ensure the converted object has the correct name (especially for DataObjects)
             if isinstance(speckle_object, DataObject):
                 converted_object.name = object_name
-                data_block_name = converted_object.data.name
+                if (
+                    hasattr(converted_object, "data")
+                    and converted_object.data is not None
+                ):
+                    data_block_name = converted_object.data.name
 
             # If there are multiple objects, parent remaining ones to the first
             for child in children[1:]:
@@ -197,6 +208,9 @@ def display_value_to_native(
     data_block_name: str,
     scale: float,
     material_mapping: Optional[Dict[str, bpy.types.Material]] = None,
+    definition_collections: Optional[Dict[str, bpy.types.Collection]] = None,
+    root_collection: Optional[bpy.types.Collection] = None,
+    instance_loading_mode: str = "INSTANCE_PROXIES",
 ) -> Tuple[Optional[bpy.types.Mesh], List[Object]]:
     """
     fallback conversion mechanism using displayValue if present
@@ -215,6 +229,9 @@ def display_value_to_native(
         DISPLAY_VALUE_PROPERTY_ALIASES,
         True,
         material_mapping,
+        definition_collections,
+        root_collection,
+        instance_loading_mode,
     )
 
     # If the parent had an applicationId and we created a mesh, apply the material
@@ -247,6 +264,9 @@ def elements_to_native(
     data_block_name: str,
     scale: float,
     material_mapping: Optional[Dict[str, bpy.types.Material]] = None,
+    definition_collections: Optional[Dict[str, bpy.types.Collection]] = None,
+    root_collection: Optional[bpy.types.Collection] = None,
+    instance_loading_mode: str = "INSTANCE_PROXIES",
 ) -> List[Object]:
     """
     convert elements collection of a speckle object
@@ -259,6 +279,9 @@ def elements_to_native(
         ELEMENTS_PROPERTY_ALIASES,
         False,
         material_mapping,
+        definition_collections,
+        root_collection,
+        instance_loading_mode,
     )
     return elements
 
@@ -271,12 +294,16 @@ def _members_to_native(
     members: Iterable[str],
     combineMeshes: bool,
     material_mapping: Optional[Dict[str, bpy.types.Material]] = None,
+    definition_collections: Optional[Dict[str, bpy.types.Collection]] = None,
+    root_collection: Optional[bpy.types.Collection] = None,
+    instance_loading_mode: str = "INSTANCE_PROXIES",
 ) -> Tuple[Optional[bpy.types.Mesh], List[Object]]:
     """
     converts a given speckle_object by converting specified members
     """
     meshes: List[Mesh] = []
     others: List[Base] = []
+    instance_proxies: List[InstanceProxy] = []
 
     for alias in members:
         display = getattr(speckle_object, alias, None)
@@ -285,10 +312,13 @@ def _members_to_native(
         MAX_DEPTH = 255  # some large value, to prevent infinite recursion
 
         def separate(value: Any) -> bool:
-            nonlocal meshes, others, count, MAX_DEPTH
+            nonlocal meshes, others, instance_proxies, count, MAX_DEPTH
 
             if combineMeshes and isinstance(value, Mesh):
                 meshes.append(value)
+            elif isinstance(value, InstanceProxy):
+                # Handle InstanceProxy objects separately - they need definition_collections
+                instance_proxies.append(value)
             elif isinstance(value, Base):
                 others.append(value)
             elif isinstance(value, list):
@@ -318,10 +348,30 @@ def _members_to_native(
     # Check if the original object is a DataObject
     is_data_object = isinstance(speckle_object, DataObject)
 
+    # Process InstanceProxy objects first with proper definition collections
+    for item in instance_proxies:
+        try:
+            blender_object = convert_to_native(
+                item,
+                material_mapping,
+                definition_collections=definition_collections,
+                root_collection=root_collection,
+                instance_loading_mode=instance_loading_mode,
+            )
+            if blender_object:
+                children.append(blender_object)
+        except Exception as ex:
+            print(f"Failed to convert instance proxy in display value {item}: {ex}")
+
+    # Process other objects
     for item in others:
         try:
             blender_object = convert_to_native(
-                item, material_mapping, instance_loading_mode="INSTANCE_PROXIES"
+                item,
+                material_mapping,
+                definition_collections=definition_collections,
+                root_collection=root_collection,
+                instance_loading_mode=instance_loading_mode,
             )
             if blender_object:
                 # If the parent is a DataObject, override the name of the converted child
@@ -987,7 +1037,14 @@ def curve_to_native(
     ):
         print("curve_to_native: degree 2 curve, falling back to displayValue")
         mesh, children = display_value_to_native(
-            speckle_curve, object_name, data_block_name, scale
+            speckle_curve,
+            object_name,
+            data_block_name,
+            scale,
+            None,
+            None,
+            None,
+            "INSTANCE_PROXIES",
         )
         if mesh:
             curve_obj = bpy.data.objects.new(object_name, mesh)
@@ -1059,7 +1116,14 @@ def polycurve_to_native(
             and speckle_polycurve.displayValue
         ):
             mesh, children = display_value_to_native(
-                speckle_polycurve, object_name, data_block_name, scale
+                speckle_polycurve,
+                object_name,
+                data_block_name,
+                scale,
+                None,
+                None,
+                None,
+                "INSTANCE_PROXIES",
             )
             if mesh:
                 curve_obj = bpy.data.objects.new(object_name, mesh)
@@ -1486,32 +1550,24 @@ def instance_proxy_to_native(
 
     location = location * unit_scale
 
-    bpy.ops.object.collection_instance_add(
-        collection=definition_collection.name,
-        align="WORLD",
-        location=(0, 0, 0),
-        rotation=(0, 0, 0),
-        scale=(1, 1, 1),
-    )
-
-    instance_obj = bpy.context.active_object
-
+    # Create collection instance directly
+    instance_name = f"Instance_{speckle_instance.id}"
+    instance_obj = bpy.data.objects.new(instance_name, None)
+    instance_obj.instance_type = "COLLECTION"
+    instance_obj.instance_collection = definition_collection
     instance_obj.empty_display_size = 0
 
-    instance_name = f"Instance_{speckle_instance.id}"
-    instance_obj.name = instance_name
+    # Link to root collection
+    root_collection.objects.link(instance_obj)
 
-    if instance_obj.name not in root_collection.objects:
-        for coll in instance_obj.users_collection:
-            coll.objects.unlink(instance_obj)
-        root_collection.objects.link(instance_obj)
-
+    # Store metadata
     instance_obj["speckle_id"] = speckle_instance.id
     instance_obj["speckle_type"] = speckle_instance.speckle_type
     instance_obj["definition_id"] = speckle_instance.definitionId
     if hasattr(speckle_instance, "maxDepth"):
         instance_obj["max_depth"] = speckle_instance.maxDepth
 
+    # Apply transformation
     final_matrix = (
         mathutils.Matrix.Translation(location)
         @ rotation.to_matrix().to_4x4()

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -1275,6 +1275,7 @@ def instance_definition_proxy_to_native(
     material_mapping: Dict[str, Any],
     processed_definitions: Dict[str, Any] = None,
     instance_loading_mode: str = "INSTANCE_PROXIES",
+    object_id_map: Optional[Dict[str, Base]] = None,
 ) -> Tuple[Dict[str, bpy.types.Collection], Dict[str, Any]]:
     """
     converts instance definition proxies to Blender collections recursively
@@ -1326,7 +1327,8 @@ def instance_definition_proxy_to_native(
         # Process objects, including nested instances
         if hasattr(definition, "objects") and isinstance(definition.objects, list):
             for obj_id in definition.objects:
-                found_obj = find_object_by_id(root_object, obj_id)
+                # Use the ID map for lookup
+                found_obj = object_id_map.get(obj_id) if object_id_map else None
 
                 if found_obj:
                     try:

--- a/bpy_speckle/converter/to_native.py
+++ b/bpy_speckle/converter/to_native.py
@@ -356,7 +356,7 @@ def _members_to_native(
                 material_mapping,
                 definition_collections=definition_collections,
                 root_collection=root_collection,
-                instance_loading_mode=instance_loading_mode,
+                instance_loading_mode="LINKED_DUPLICATES",  # always use Linked Duplicates for displayValue proxies
             )
             if blender_object:
                 children.append(blender_object)

--- a/bpy_speckle/converter/utils.py
+++ b/bpy_speckle/converter/utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Dict
 import bpy
 import mathutils
 from specklepy.objects import Base
@@ -116,6 +116,25 @@ def transform_matrix(transform: List[float]) -> mathutils.Matrix:
             (transform[3], transform[7], transform[11], transform[15]),
         )
     )
+
+
+def build_object_id_map(root_object: Base) -> Dict[str, Base]:
+    """
+    Builds a dictionary mapping object IDs (both id and applicationId) to objects.
+    """
+    id_map = {}
+    traversal_function = create_default_traversal_function()
+
+    for traversal_item in traversal_function.traverse(root_object):
+        obj = traversal_item.current
+
+        if hasattr(obj, "id") and obj.id:
+            id_map[obj.id] = obj
+
+        if hasattr(obj, "applicationId") and obj.applicationId:
+            id_map[obj.applicationId] = obj
+
+    return id_map
 
 
 def find_object_by_id(root_object: Base, target_id: str) -> Optional[Base]:


### PR DESCRIPTION
This PR implements the handling for proxies in displayValue.
- Separates InstanceProxy objects into their own list
- Processes them first with instance definition context
- Then processes other objects
- Ensures instance proxies have access to the instance definitions they reference

Also:
- Replaced slow `bpy.ops.object.collection_instance_add()` operator calls with direct blender python API calls, dramatically improving collection instance loading speed