### PR TITLE
bump specklepy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Next-Gen Speckle connector for Blender!"
 requires-python = ">=3.11.9, <4.0.0"
 license = "Apache-2.0"
 dependencies = [
-    "specklepy>=3.0.4",
+    "specklepy>=3.2.3",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Root cause of the issue has been addressed in specklepy in earlier versions. Blender connector was using an older version. Bumping the specklepy version has resolved the issue.