### PR TITLE
fix: remove comma blender_manifest.toml

### DIFF
--- a/patch_version.py
+++ b/patch_version.py
@@ -30,7 +30,7 @@ def patch_manifest(simple_version: str):
 
         for index, line in enumerate(lines):
             if line.startswith("version ="):
-                lines[index] = f'version = "{version[0]}.{version[1]}.{version[2]}",\n'
+                lines[index] = f'version = "{version[0]}.{version[1]}.{version[2]}"\n'
                 print(f"Patched connector version number in {FILE_PATH}")
                 break
 


### PR DESCRIPTION
When i try to import the zip file into blender, it throws an error:

Failed to load manifest from: Archive contains a manifest that could not be parsed Expected newline or end of document after a statement (at line 6, column 18)

This is because of a comma in line 6.

This PR removes that comma.