### PR TITLE
fix: Change auth port and app slug

### DIFF
--- a/bpy_speckle/connector/blender_operators/add_account_button.py
+++ b/bpy_speckle/connector/blender_operators/add_account_button.py
@@ -4,14 +4,12 @@ from bpy.types import Event, Context
 from typing import Optional
 from ..utils.authentication import (
     AuthenticationServer,
-    DesktopServiceAuthenticator,
     SPECKLE_AUTH_PORT,
 )
 
 
-# Global auth server/authenticator instance
+# Global auth server instance
 _auth_server = None
-_desktop_authenticator = None
 
 
 class SPECKLE_OT_add_account(bpy.types.Operator):
@@ -50,11 +48,14 @@ class SPECKLE_OT_add_account(bpy.types.Operator):
         if _auth_server.start():
             return self._initiate_own_server_flow(context)
 
-        # Server failed to start - assume Desktop Service is running
+        # Server failed to start - port is in use
         _auth_server = None
-        print(f"[Add Account] Port {SPECKLE_AUTH_PORT} in use, using Desktop Service")
-        self.report({"INFO"}, "Authenticating via Speckle Desktop Service...")
-        return self._initiate_desktop_service_flow(context)
+        print(f"[Add Account] Port {SPECKLE_AUTH_PORT} is already in use")
+        self.report(
+            {"ERROR"},
+            f"Port {SPECKLE_AUTH_PORT} is already in use. Please close any application using it and try again.",
+        )
+        return {"CANCELLED"}
 
     def _initiate_own_server_flow(self, context: Context) -> set[str]:
         """Start auth flow with our own server."""
@@ -68,22 +69,6 @@ class SPECKLE_OT_add_account(bpy.types.Operator):
             cleanup_auth_server()
             return {"CANCELLED"}
 
-    def _initiate_desktop_service_flow(self, context: Context) -> set[str]:
-        """Start auth flow with Desktop Service."""
-        global _desktop_authenticator
-        _desktop_authenticator = DesktopServiceAuthenticator(self.server_url)
-
-        if not _desktop_authenticator.start():
-            error_msg = _desktop_authenticator.get_error_message()
-            self.report(
-                {"ERROR"}, error_msg or "Failed to open browser. Please try again."
-            )
-            _desktop_authenticator = None
-            return {"CANCELLED"}
-
-        self._start_modal_timer(context)
-        return {"RUNNING_MODAL"}
-
     def _start_modal_timer(self, context: Context):
         """Start modal timer for auth polling."""
         self._timeout_counter = 0
@@ -92,7 +77,7 @@ class SPECKLE_OT_add_account(bpy.types.Operator):
         wm.modal_handler_add(self)
 
     def modal(self, context: Context, event: Event) -> set[str]:
-        global _auth_server, _desktop_authenticator
+        global _auth_server
 
         if event.type != "TIMER":
             return {"PASS_THROUGH"}
@@ -108,30 +93,19 @@ class SPECKLE_OT_add_account(bpy.types.Operator):
             )
             return {"CANCELLED"}
 
-        # Check for no active authenticator
-        if not _desktop_authenticator and not _auth_server:
-            print("[Add Account] No active authenticator, cancelling")
+        # Check for no active auth server
+        if not _auth_server:
+            print("[Add Account] No active auth server, cancelling")
             self._cleanup(context)
             return {"CANCELLED"}
 
-        # Check Desktop Service authentication
-        if _desktop_authenticator:
-            _desktop_authenticator.check_for_new_account()
-            if _desktop_authenticator.is_complete():
-                return self._finish_auth(
-                    context,
-                    _desktop_authenticator.is_successful(),
-                    _desktop_authenticator.get_error_message(),
-                    "Desktop Service",
-                )
-
-        # Check own server authentication
-        if _auth_server and _auth_server.is_complete():
+        # Check auth server completion
+        if _auth_server.is_complete():
             return self._finish_auth(
                 context,
                 _auth_server.is_successful(),
                 _auth_server.get_error_message(),
-                "Own server",
+                "Auth server",
             )
 
         # Still waiting
@@ -211,8 +185,8 @@ class SPECKLE_OT_add_account(bpy.types.Operator):
 
 
 def cleanup_auth_server():
-    """Shutdown auth server/authenticator on addon unload."""
-    global _auth_server, _desktop_authenticator
+    """Shutdown auth server on addon unload."""
+    global _auth_server
 
     if _auth_server is not None:
         try:
@@ -221,9 +195,6 @@ def cleanup_auth_server():
             print(f"[Add Account] Failed to cleanup auth server: {e}")
             print(f"[Add Account] Port {SPECKLE_AUTH_PORT} may still be occupied")
         _auth_server = None
-
-    if _desktop_authenticator is not None:
-        _desktop_authenticator = None
 
 
 class SPECKLE_OT_show_auth_error(bpy.types.Operator):

--- a/bpy_speckle/connector/utils/authentication.py
+++ b/bpy_speckle/connector/utils/authentication.py
@@ -18,9 +18,9 @@ from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
 
-# Speckle Desktop Authentication Service protocol constants
-SPECKLE_APP_ID = "sdas"  # App ID for Speckle Desktop Auth Service protocol
-SPECKLE_AUTH_PORT = 29364  # Default port for local auth callback server
+# Speckle Blender dedicated app constants (registered server-side)
+SPECKLE_APP_ID = "sblndrdui"  # Dedicated app ID for Blender connector
+SPECKLE_AUTH_PORT = 29365  # Port for local auth callback server
 
 
 def get_user_agent() -> str:
@@ -364,36 +364,6 @@ def get_user_and_server_info(
     return user_info, server_info
 
 
-def get_account_count() -> int:
-    """Get the current number of accounts in Accounts.db."""
-    try:
-        import sqlite3
-        import os
-        from specklepy.core.api.credentials import speckle_path_provider
-
-        # Get database path
-        speckle_folder = speckle_path_provider.user_speckle_folder_path()
-        db_path = os.path.join(speckle_folder, "Accounts.db")
-
-        # If database doesn't exist, no accounts
-        if not os.path.exists(db_path):
-            return 0
-
-        # Count accounts in database
-        conn = sqlite3.connect(db_path)
-        try:
-            with conn:
-                cursor = conn.cursor()
-                cursor.execute("SELECT COUNT(*) FROM objects")
-                result = cursor.fetchone()
-                return result[0] if result else 0
-        finally:
-            conn.close()
-    except Exception as e:
-        print(f"[Account Count] Error counting accounts: {e}")
-        return 0
-
-
 def save_account_to_storage(
     token: str,
     refresh_token: str,
@@ -510,63 +480,6 @@ def save_account_to_storage(
         raise AuthenticationError(f"Failed to save account: {e}")
 
 
-class DesktopServiceAuthenticator:
-    """Handles authentication via Speckle Desktop Service by delegating to its endpoint."""
-
-    def __init__(self, server_url: str):
-        self.server_url = server_url
-        self._initial_account_count = get_account_count()
-        self._auth_complete = False
-        self._auth_success = False
-        self._error_message: Optional[str] = None
-
-    def start(self) -> bool:
-        """Open browser to Desktop Service endpoint to initiate OAuth flow."""
-        try:
-            auth_url = f"http://127.0.0.1:{SPECKLE_AUTH_PORT}/auth/add-account?serverUrl={self.server_url}"
-            webbrowser.open(auth_url)
-            print(
-                f"[Desktop Service Auth] Opening browser to Desktop Service: {auth_url}"
-            )
-            return True
-        except Exception as e:
-            print(f"[Desktop Service Auth] Failed to open browser: {e}")
-            self._error_message = f"Failed to open browser: {e}"
-            return False
-
-    def check_for_new_account(self) -> bool:
-        """Check if a new account has been added to storage."""
-        try:
-            current_count = get_account_count()
-            if current_count > self._initial_account_count:
-                # New account detected!
-                print(
-                    f"[Desktop Service Auth] New account detected (count: {self._initial_account_count} -> {current_count})"
-                )
-                self._auth_complete = True
-                self._auth_success = True
-                return True
-
-            # Still waiting
-            return False
-
-        except Exception as e:
-            print(f"[Desktop Service Auth] Error checking for new account: {e}")
-            self._auth_complete = True
-            self._auth_success = False
-            self._error_message = f"Error checking for new account: {e}"
-            return True
-
-    def is_complete(self) -> bool:
-        return self._auth_complete
-
-    def is_successful(self) -> bool:
-        return self._auth_success
-
-    def get_error_message(self) -> Optional[str]:
-        return self._error_message
-
-
 class AuthenticationServer:
     """Manages local HTTP server for Speckle authentication in a background thread."""
 
@@ -593,9 +506,7 @@ class AuthenticationServer:
 
         except OSError as e:
             if e.errno == 98 or e.errno == 10048:  # Address already in use
-                print(
-                    f"[Auth Server] Port {self.port} is already in use. Is desktop service running?"
-                )
+                print(f"[Auth Server] Port {self.port} is already in use.")
             else:
                 print(f"[Auth Server] Failed to start server: {e}")
             return False

--- a/bpy_speckle/connector/utils/authentication.py
+++ b/bpy_speckle/connector/utils/authentication.py
@@ -5,6 +5,7 @@ Implements OAuth-style authentication flow with a local HTTP server,
 eliminating the dependency on the desktop service.
 """
 
+import errno
 import json
 import secrets
 import string
@@ -505,7 +506,7 @@ class AuthenticationServer:
             return True
 
         except OSError as e:
-            if e.errno == 98 or e.errno == 10048:  # Address already in use
+            if e.errno in (errno.EADDRINUSE, 10048):  # Address already in use
                 print(f"[Auth Server] Port {self.port} is already in use.")
             else:
                 print(f"[Auth Server] Failed to start server: {e}")


### PR DESCRIPTION
Switches the Blender connector to use its own dedicated app ID (`sblndrdui`) and auth port (`29365`), removing the dependency on the Speckle Desktop Auth Service

## Changes

### `bpy_speckle/connector/utils/authentication.py`
- Changed `SPECKLE_APP_ID` from `"sdas"` to `"sblndrdui"` (dedicated Blender app registered server-side)
- Changed `SPECKLE_AUTH_PORT` from `29364` to `29365` to avoid conflicts with Desktop Service
- Removed `DesktopServiceAuthenticator` class and `get_account_count()` function
- Fixed errno check to use `errno.EADDRINUSE` constant instead of magic number `98`

### `bpy_speckle/connector/blender_operators/add_account_button.py`
- Removed Desktop Service fallback flow — port conflicts now report an error and cancel
- Removed `_desktop_authenticator` global and all related branching in `modal()` and `invoke()`
- Simplified `cleanup_auth_server()` to only handle the auth server